### PR TITLE
Verify parameter is now passed down to Requests which allows for self-signed SSL certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ pip install python-nomad
 
 import nomad
 
-# For non-HTTPS Nomad instances
+# For HTTP Nomad instances
 n = nomad.Nomad("172.16.100.10",timeout=5)
 
 # For HTTPS Nomad instances with non-self-signed SSL certificates

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 
 Branch | Status | Coverage |
----| ---| --- 
+---| ---| ---
 develop | [![Build Status](https://travis-ci.org/jrxFive/python-nomad.svg?branch=develop)](https://travis-ci.org/jrxFive/python-nomad) | [![codecov](https://codecov.io/gh/jrxFive/python-nomad/branch/develop/graph/badge.svg)](https://codecov.io/gh/jrxFive/python-nomad)
 
 
@@ -16,13 +16,20 @@ pip install python-nomad
 
 import nomad
 
+# For non-HTTPS Nomad instances
 n = nomad.Nomad("172.16.100.10",timeout=5)
+
+# For HTTPS Nomad instances with non-self-signed SSL certificates
+n = nomad.Nomad("172.16.100.10",timeout=5,verify=True)
+
+# For HTTPS Nomad instances with self-signed SSL certificates
+n = nomad.Nomad("172.16.100.10",timeout=5,verify="/path/to/certfile") # See http://docs.python-requests.org/en/master/user/advanced/#ssl-cert-verification
 
 "example" in n.jobs
 
 j = n.jobs["example"]["ID"]
 
-example_allocation = n.allocation.get_allocations(j)
+example_allocation = n.job.get_allocations(j)
 
 n.job.deregister_job(j)
 ```

--- a/nomad/api/base.py
+++ b/nomad/api/base.py
@@ -27,7 +27,6 @@ class Requester(object):
             proto=proto,
             uri=self.uri,
             port=self.port,
-            verify=self.verify,
             endpoint=endpoint)
 
     def get(self, endpoint, params=None):

--- a/nomad/api/base.py
+++ b/nomad/api/base.py
@@ -37,6 +37,7 @@ class Requester(object):
         try:
             response = self.session.get(url,
                                         params=params,
+                                        verify=self.verify,
                                         timeout=self.timeout)
 
             if response.ok:
@@ -53,7 +54,7 @@ class Requester(object):
 
         try:
             response = self.session.post(
-                url, params=params, json=json, headers=headers, data=data, timeout=self.timeout)
+                url, params=params, json=json, headers=headers, data=data, verify=self.verify, timeout=self.timeout)
 
             if response.ok:
                 return response
@@ -69,7 +70,7 @@ class Requester(object):
 
         try:
             response = self.session.put(
-                url, params=params, headers=headers, data=data, timeout=self.timeout)
+                url, params=params, headers=headers, data=data, verify=self.verify, timeout=self.timeout)
 
             if response.ok:
                 return response
@@ -85,7 +86,7 @@ class Requester(object):
 
         try:
             response = self.session.delete(
-                url, params=params, headers=headers, timeout=self.timeout)
+                url, params=params, headers=headers, verify=self.verify, timeout=self.timeout)
 
             if response.ok:
                 return response


### PR DESCRIPTION
Fixes #32 

- Add  HTTPS examples to the README
- Fix the allocation example in the README