### PR TITLE
Add methods to return resources used by nodes and allocations.

### DIFF
--- a/nomad/api/client.py
+++ b/nomad/api/client.py
@@ -8,6 +8,8 @@ class Client(object):
         self.ls = ls(requester)
         self.cat = cat(requester)
         self.stat = stat(requester)
+        self.stats = stats(requester)
+        self.allocation = allocation(requester)
 
     def __str__(self):
         return "{0}".format(self.__dict__)
@@ -21,7 +23,7 @@ class Client(object):
     def _get(self, *args, **kwargs):
         try:
             url = self._requester._endpointBuilder(
-                Client.ENDPOINT, "fs", *args)
+                Client.ENDPOINT, *args)
 
             response = self._requester.get(url, params=kwargs)
 
@@ -42,7 +44,7 @@ class ls(Client):
     https://www.nomadproject.io/docs/http/client-fs-ls.html
     """
 
-    ENDPOINT = "ls"
+    ENDPOINT = "fs/ls"
 
     def __init__(self, requester):
         self._requester = requester
@@ -74,7 +76,7 @@ class cat(Client):
     https://www.nomadproject.io/docs/http/client-fs-cat.html
     """
 
-    ENDPOINT = "cat"
+    ENDPOINT = "fs/cat"
 
     def __init__(self, requester):
         self._requester = requester
@@ -98,14 +100,14 @@ class cat(Client):
 class stat(Client):
 
     """
-    The /fs/ls endpoint is used to list files in an allocation directory.
+    The /fs/stat endpoint is used to show stat information 
     This API endpoint is hosted by the Nomad client and requests have to be
     made to the Nomad client where the particular allocation was placed.
 
     https://www.nomadproject.io/docs/http/client-fs-stat.html
     """
 
-    ENDPOINT = "stat"
+    ENDPOINT = "fs/stat"
 
     def __init__(self, requester):
         self._requester = requester
@@ -124,3 +126,63 @@ class stat(Client):
               - nomad.api.exceptions.URLNotFoundNomadException
         """
         return self._get(stat.ENDPOINT, id, path=path)
+
+
+class stats(Client):
+
+    """
+    The /stats endpoint queries the actual resources consumed on a node.
+    The API endpoint is hosted by the Nomad client and requests have to
+    be made to the nomad client whose resource usage metrics are of interest.
+
+    https://www.nomadproject.io/api/client.html#read-stats
+    """
+
+    ENDPOINT = "stats"
+
+    def __init__(self, requester):
+        self._requester = requester
+
+    def read_stats(self):
+        """ Query the actual resources consumed on a node.
+
+            https://www.nomadproject.io/api/client.html#read-stats
+
+            arguments:
+            returns: dict
+            raises:
+              - nomad.api.exceptions.BaseNomadException
+              - nomad.api.exceptions.URLNotFoundNomadException
+        """
+        return self._get(stats.ENDPOINT)
+
+
+class allocation(Client):
+
+    """
+    The allocation/:alloc_id/stats endpoint is used to query the actual
+    resources consumed by an allocation. The API endpoint is hosted by the 
+    Nomad client and requests have to be made to the nomad client whose 
+    resource usage metrics are of interest.
+
+    https://www.nomadproject.io/api/client.html#read-allocation
+    """
+
+    ENDPOINT = "allocation"
+
+    def __init__(self, requester):
+        self._requester = requester
+
+    def read_allocation_stats(self, id):
+        """ Query the actual resources consumed by an allocation.
+
+            https://www.nomadproject.io/api/client.html#read-allocation
+
+            arguments:
+              - id
+            returns: dict
+            raises:
+              - nomad.api.exceptions.BaseNomadException
+              - nomad.api.exceptions.URLNotFoundNomadException
+        """
+        return self._get(allocation.ENDPOINT, id, "stats")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -45,6 +45,21 @@ def test_cat_read_file(nomad_setup):
     # f = nomad_setup.client.cat.read_file(a,"/redis/redis-executor.out")
 
 
+def test_read_stats(nomad_setup):
+    """Use Functioncal Test Instead"""
+    # test_register_job(nomad_setup)
+    #
+    # f = nomad_setup.client.stats.read_stats()
+
+
+def test_read_allocation_stats(nomad_setup):
+    """Use Functioncal Test Instead"""
+    # test_register_job(nomad_setup)
+    #
+    # a = nomad_setup.allocations.get_allocations()[0]["ID"]
+    # f = nomad_setup.client.allocation.read_allocation(a)
+
+
 def test_dunder_str(nomad_setup):
     assert isinstance(str(nomad_setup.client), str)
     assert isinstance(str(nomad_setup.client.ls), str)


### PR DESCRIPTION
Nomad provides read stats (https://www.nomadproject.io/api/client.html#read-stats) and read allocation (https://www.nomadproject.io/api/client.html#read-allocation) methods to query resources consumed by the Node and the allocation specified. These methods are added to the sdk.

Addresses #38