### PR TITLE
feat(align:envs) Align enviorment variables to match nomad clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,20 @@ example_allocation = n.job.get_allocations(j)
 n.job.deregister_job(j)
 ```
 
+## Environment Variables
+
+This library also supports environment variables: `NOMAD_ADDR`, `NOMAD_NAMESPACE`, `NOMAD_TOKEN`, `NOMAD_REGION` for ease of configuration
+and unifying with nomad cli tools and other libraries.
+
+```bash
+NOMAD_ADDR=http://127.0.0.1:4646
+NOMAD_NAMESPACE=default
+NOMAD_TOKEN=xxxx-xxxx-xxxx-xxxx
+NOMAD_REGION=us-east-1a
+```
+
 ## Class Dunders
+
 | Class | contains | len | getitem | iter |
 |---|---|---|---|---|
 |agent|N|N|N|N

--- a/nomad/__init__.py
+++ b/nomad/__init__.py
@@ -1,11 +1,21 @@
 
 import nomad.api as api
-
+import os
 
 class Nomad(object):
 
-    def __init__(self, host='127.0.0.1', secure=False, port=4646, namespace=None,
-        token=None, timeout=5, region=None, version='v1', verify=False, cert=()):
+    def __init__(self, 
+        host='127.0.0.1', 
+        secure=False, 
+        port=4646,
+        address=os.getenv('NOMAD_ADDR', None),
+        namespace=os.getenv('NOMAD_NAMESPACE', None),
+        token=os.getenv('NOMAD_TOKEN', None), 
+        timeout=5, 
+        region=os.getenv('NOMAD_REGION', None), 
+        version='v1', 
+        verify=False, 
+        cert=()):
         """ Nomad api client
 
           https://github.com/jrxFive/python-nomad/
@@ -35,13 +45,14 @@ class Nomad(object):
         self.host = host
         self.secure = secure
         self.port = port
+        self.address = address
         self.timeout = timeout
         self.version = version
         self.verify = verify
         self.cert = cert
 
-        self.requester = api.Requester(self.get_uri(), port, namespace, token,
-                                       timeout, version, verify, cert)
+        self.requester = api.Requester(address=address, uri=self.get_uri(), port=port, namespace=namespace,
+                                        token=token, timeout=timeout, version=version, verify=verify, cert=cert)
 
         self._jobs = api.Jobs(self.requester)
         self._job = api.Job(self.requester)

--- a/nomad/api/base.py
+++ b/nomad/api/base.py
@@ -7,7 +7,7 @@ requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
 class Requester(object):
 
-    def __init__(self, uri='http://127.0.0.1', port=4646, namespace=None, token=None, timeout=5, version='v1', verify=False, cert=()):
+    def __init__(self, address=None, uri='http://127.0.0.1', port=4646, namespace=None, token=None, timeout=5, version='v1', verify=False, cert=()):
         self.uri = uri
         self.port = port
         self.namespace = namespace
@@ -16,6 +16,7 @@ class Requester(object):
         self.version = version
         self.verify = verify
         self.cert = cert
+        self.address = address
         self.session = requests.Session()
 
     def _endpointBuilder(self, *args):
@@ -44,9 +45,12 @@ class Requester(object):
         return required
 
     def _urlBuilder(self, endpoint):
-        url = "{uri}:{port}/{endpoint}".format(uri=self.uri,
-                                               port=self.port,
-                                               endpoint=endpoint)
+        url = self.address
+        if self.address is None:
+           url = "{uri}:{port}".format(uri=self.uri,
+                                        port=self.port)
+        url = "{url}/{endpoint}".format(url=url,
+                                        endpoint=endpoint)
         if self.namespace:
             if self._required_namespace(endpoint):
                 url = "{url}?namespace={namespace}".format(

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,4 @@ pytest-cov==2.2.1
 requests==2.10.0
 mkdocs==0.15.3
 mock==1.2.0
+requests-mock==1.4.0

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -40,9 +40,9 @@ def test_base_get_connnection_not_authorized():
     with pytest.raises(nomad.api.exceptions.URLNotAuthorizedNomadException):
         j = n.job.get_job("example")
 
-@requests_mock.mock()
-def test_base_use_address_instead_on_host_port(mock):
-    mock.get('https://nomad.service.consul:4646/v1/jobs', text='[]')
-    nomad_address = "https://nomad.service.consul:4646"
-    n = nomad.Nomad(address=nomad_address, host=common.IP, port=common.NOMAD_PORT, verify=False, token=common.NOMAD_TOKEN)
-    n.jobs.get_jobs()
+def test_base_use_address_instead_on_host_port():
+    with requests_mock.Mocker() as m:
+        m.get('https://nomad.service.consul:4646/v1/jobs', text='[]')
+        nomad_address = "https://nomad.service.consul:4646"
+        n = nomad.Nomad(address=nomad_address, host=common.IP, port=common.NOMAD_PORT, verify=False, token=common.NOMAD_TOKEN)
+        n.jobs.get_jobs()

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -3,7 +3,7 @@ import tests.common as common
 import nomad
 from nomad.api import exceptions
 import os
-
+import requests_mock
 
 @pytest.fixture
 def nomad_setup():
@@ -39,3 +39,10 @@ def test_base_get_connnection_not_authorized():
         host=common.IP, port=common.NOMAD_PORT, token='aed2fc63-c155-40d5-b58a-18deed4b73e5', verify=False)
     with pytest.raises(nomad.api.exceptions.URLNotAuthorizedNomadException):
         j = n.job.get_job("example")
+
+@requests_mock.mock()
+def test_base_use_address_instead_on_host_port(mock):
+    mock.get('https://nomad.service.consul:4646/v1/jobs', text='[]')
+    nomad_address = "https://nomad.service.consul:4646"
+    n = nomad.Nomad(address=nomad_address, host=common.IP, port=common.NOMAD_PORT, verify=False, token=common.NOMAD_TOKEN)
+    n.jobs.get_jobs()


### PR DESCRIPTION
Align libraries environment variables to match those of nomad client.
`NOMAD_ADDR` and `address` were added and and supporting backward comparability.