### PR TITLE
Nomad node drain 0.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,9 @@ services:
 language: python
 python:
 - '2.7'
-- '3.3'
 - '3.4'
 - '3.5'
+- '3.6'
 env:
   global:
   - NOMAD_IP="127.0.0.1"
@@ -27,8 +27,8 @@ env:
   - NOMAD_VERSION="0.4.1"
   - NOMAD_VERSION="0.5.6"
   - NOMAD_VERSION="0.6.0"
-  - NOMAD_VERSION="0.7.0"
   - NOMAD_VERSION="0.7.1"
+  - NOMAD_VERSION="0.8.1"
 before_install:
 - curl -L -o /tmp/nomad_${NOMAD_VERSION}_linux_amd64.zip https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}_linux_amd64.zip
 - yes | unzip -d /tmp /tmp/nomad_${NOMAD_VERSION}_linux_amd64.zip

--- a/README.md
+++ b/README.md
@@ -28,14 +28,14 @@ n = nomad.Nomad(host="172.16.100.10", secure=True, timeout=5, verify=True)
 # For HTTPS Nomad instances with self-signed SSL certificates and no validate the cert
 n = nomad.Nomad(host="172.16.100.10", secure=True, timeout=5, verify=False)
 
-# For HTTPS Nomad instances with self-signed SSL certificates that mus validate with cert
+# For HTTPS Nomad instances with self-signed SSL certificates that must validate with cert
 n = nomad.Nomad(host="172.16.100.10", secure=True, timeout=5, verify=True, cert="/path/to/certfile") # See http://docs.python-requests.org/en/master/user/advanced/#ssl-cert-verification
 
 # For HTTPS Nomad instances with cert file and key
-n = nomad.Nomad(host="https://172.16.100.10", secure=True, timeout=5, verify=True, cert=("/path/to/certfile", "/path/to/key") # See http://docs.python-requests.org/en/master/user/advanced/#ssl-cert-verification
+n = nomad.Nomad(host="https://172.16.100.10", secure=True, timeout=5, verify=True, cert=("/path/to/certfile", "/path/to/key")) # See http://docs.python-requests.org/en/master/user/advanced/#ssl-cert-verification
 
 # For HTTPS Nomad instances with namespace and acl token
-n = nomad.Nomad(host="172.16.100.10", secure=True timeout=5, verify=False, namespace='Namespace-example',token='3f4a0fcd-7c42-773c-25db-2d31ba0c05fe')
+n = nomad.Nomad(host="172.16.100.10", secure=True, timeout=5, verify=False, namespace='Namespace-example',token='3f4a0fcd-7c42-773c-25db-2d31ba0c05fe')
 
 "example" in n.jobs
 

--- a/docs/api/jobs.md
+++ b/docs/api/jobs.md
@@ -18,3 +18,107 @@ jobs = my_nomad.jobs.get_jobs()
 for job in jobs:
   print (job)
 ```
+
+### Create new job
+
+This endpoint creates (aka "registers") a new job in the system.
+
+https://www.nomadproject.io/api/jobs.html#create-job
+
+Example:
+
+```
+import nomad
+
+job = {'Job': {'AllAtOnce': None,
+  'Constraints': None,
+  'CreateIndex': None,
+  'Datacenters': ['dc1'],
+  'ID': 'example',
+  'JobModifyIndex': None,
+  'Meta': None,
+  'ModifyIndex': None,
+  'Name': 'example',
+  'Namespace': None,
+  'ParameterizedJob': None,
+  'ParentID': None,
+  'Payload': None,
+  'Periodic': None,
+  'Priority': None,
+  'Region': None,
+  'Stable': None,
+  'Status': None,
+  'StatusDescription': None,
+  'Stop': None,
+  'SubmitTime': None,
+  'TaskGroups': [{'Constraints': None,
+    'Count': 1,
+    'EphemeralDisk': {'Migrate': None, 'SizeMB': 300, 'Sticky': None},
+    'Meta': None,
+    'Name': 'cache',
+    'RestartPolicy': {'Attempts': 10,
+     'Delay': 25000000000,
+     'Interval': 300000000000,
+     'Mode': 'delay'},
+    'Tasks': [{'Artifacts': None,
+      'Config': {'image': 'redis:3.2', 'port_map': [{'db': 6379}]},
+      'Constraints': None,
+      'DispatchPayload': None,
+      'Driver': 'docker',
+      'Env': None,
+      'KillTimeout': None,
+      'Leader': False,
+      'LogConfig': None,
+      'Meta': None,
+      'Name': 'redis',
+      'Resources': {'CPU': 500,
+       'DiskMB': None,
+       'IOPS': None,
+       'MemoryMB': 256,
+       'Networks': [{'CIDR': '',
+         'Device': '',
+         'DynamicPorts': [{'Label': 'db', 'Value': 0}],
+         'IP': '',
+         'MBits': 10,
+         'ReservedPorts': None}]},
+      'Services': [{'AddressMode': '',
+        'CheckRestart': None,
+        'Checks': [{'Args': None,
+          'CheckRestart': None,
+          'Command': '',
+          'Header': None,
+          'Id': '',
+          'InitialStatus': '',
+          'Interval': 10000000000,
+          'Method': '',
+          'Name': 'alive',
+          'Path': '',
+          'PortLabel': '',
+          'Protocol': '',
+          'TLSSkipVerify': False,
+          'Timeout': 2000000000,
+          'Type': 'tcp'}],
+        'Id': '',
+        'Name': 'global-redis-check',
+        'PortLabel': 'db',
+        'Tags': ['global', 'cache']}],
+      'ShutdownDelay': 0,
+      'Templates': None,
+      'User': '',
+      'Vault': None}],
+    'Update': None}],
+  'Type': 'service',
+  'Update': {'AutoRevert': False,
+   'Canary': 0,
+   'HealthCheck': None,
+   'HealthyDeadline': 180000000000,
+   'MaxParallel': 1,
+   'MinHealthyTime': 10000000000,
+   'Stagger': None},
+  'VaultToken': None,
+  'Version': None}}
+
+my_nomad = nomad.Nomad(host='192.168.33.10')
+
+response = my_nomad.jobs.register_job(job)
+```

--- a/docs/api/metrics.md
+++ b/docs/api/metrics.md
@@ -1,0 +1,15 @@
+## Metrics
+
+### Get node metrics
+
+https://www.nomadproject.io/api/metrics.html
+
+Example:
+
+```
+import nomad
+
+my_nomad = nomad.Nomad(host='192.168.33.10')
+
+metrics = my_nomad.metrics.get_metrics()
+```

--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -67,3 +67,65 @@ my_nomad = nomad.Nomad(host='192.168.33.10')
 
 my_nomad.node.drain_node('ed1bbae7-c38a-df2d-1de7-50dbc753fc98')
 ```
+
+### Drain node with DrainSpec
+
+This endpoint toggles the drain mode of the node. When draining is enabled, no further allocations will be assigned to this node, and existing allocations will be migrated to new nodes.
+
+https://www.nomadproject.io/api/nodes.html#drain-node
+
+Example:
+
+```
+import nomad
+
+my_nomad = nomad.Nomad(host='192.168.33.10')
+
+#enable drain mode
+my_nomad.node.drain_node('ed1bbae7-c38a-df2d-1de7-50dbc753fc98', drain_spec={"Duration": "100000000"})
+
+#enable drain mode but leave system jobs on the specificed node
+my_nomad.node.drain_node('ed1bbae7-c38a-df2d-1de7-50dbc753fc98', drain_spec={"Duration": "100000000", "IgnoreSystemJobs": True})
+
+#disable drain but leave node in an ineligible state
+my_nomad.node.drain_node('ed1bbae7-c38a-df2d-1de7-50dbc753fc98', drain_spec={})
+
+#disable drain and put node in an eligible state
+my_nomad.node.drain_node('ed1bbae7-c38a-df2d-1de7-50dbc753fc98', drain_spec={}, mark_eligible=True)
+```
+
+### Eligible Node
+
+This endpoint toggles the eligibility of the node. When a node's "SchedulingEligibility" is ineligible  the scheduler will not consider it for new placements.
+
+https://www.nomadproject.io/api/nodes.html#drain-node
+
+Example:
+
+```
+import nomad
+
+my_nomad = nomad.Nomad(host='192.168.33.10')
+
+# sets node to ineligible state
+my_nomad.node.eligible_node('ed1bbae7-c38a-df2d-1de7-50dbc753fc98', ineligible=True)
+
+# sets node to eligible state
+my_nomad.node.eligible_node('ed1bbae7-c38a-df2d-1de7-50dbc753fc98', eligible=True)
+```
+
+### Purge Node
+
+This endpoint purges a node from the system. Nodes can still join the cluster if they are alive.
+
+https://www.nomadproject.io/api/nodes.html#purge-node
+
+Example:
+
+```
+import nomad
+
+my_nomad = nomad.Nomad(host='192.168.33.10')
+
+my_nomad.node.purge_node('ed1bbae7-c38a-df2d-1de7-50dbc753fc98')
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,91 @@
+## Installation
+```
+pip install python-nomad
+```
+
+## Examples
+```python
+
+
+import nomad
+# For HTTP Nomad instances
+n = nomad.Nomad(host="172.16.100.10", timeout=5)
+
+# For HTTPS Nomad instances with non-self-signed SSL certificates
+n = nomad.Nomad(host="172.16.100.10", secure=True, timeout=5, verify=True)
+
+# For HTTPS Nomad instances with self-signed SSL certificates and no validate the cert
+n = nomad.Nomad(host="172.16.100.10", secure=True, timeout=5, verify=False)
+
+# For HTTPS Nomad instances with self-signed SSL certificates that must validate with cert
+n = nomad.Nomad(host="172.16.100.10", secure=True, timeout=5, verify=True, cert="/path/to/certfile") # See http://docs.python-requests.org/en/master/user/advanced/#ssl-cert-verification
+
+# For HTTPS Nomad instances with cert file and key
+n = nomad.Nomad(host="https://172.16.100.10", secure=True, timeout=5, verify=True, cert=("/path/to/certfile", "/path/to/key")) # See http://docs.python-requests.org/en/master/user/advanced/#ssl-cert-verification
+
+# For HTTPS Nomad instances with namespace and acl token
+n = nomad.Nomad(host="172.16.100.10", secure=True, timeout=5, verify=False, namespace='Namespace-example',token='3f4a0fcd-7c42-773c-25db-2d31ba0c05fe')
+
+"example" in n.jobs
+
+j = n.jobs["example"]["ID"]
+
+example_allocation = n.job.get_allocations(j)
+
+n.job.deregister_job(j)
+```
+
+## Environment Variables
+
+This library also supports environment variables: `NOMAD_ADDR`, `NOMAD_NAMESPACE`, `NOMAD_TOKEN`, `NOMAD_REGION` for ease of configuration
+and unifying with nomad cli tools and other libraries.
+
+```bash
+NOMAD_ADDR=http://127.0.0.1:4646
+NOMAD_NAMESPACE=default
+NOMAD_TOKEN=xxxx-xxxx-xxxx-xxxx
+NOMAD_REGION=us-east-1a
+```
+
+## Class Dunders
+
+| Class | contains | len | getitem | iter |
+|---|---|---|---|---|
+|agent|N|N|N|N
+|allocation|Y|N|Y|N
+|allocations|N|Y|N|Y
+|client|N|N|N|N
+|evaluation|Y|N|Y|N
+|evaluations|Y|Y|Y|Y
+|job|Y|N|Y|N
+|jobs|Y|Y|Y|Y
+|node|Y|N|Y|N
+|nodes|Y|Y|Y|Y
+|regions|Y|Y|Y|Y
+|status.leader|Y|Y|N|N
+|status.peers|Y|Y|Y|Y
+|system|N|N|N|N
+|validate|N|N|N|N
+|deployments|Y|Y|Y|Y
+|deployment|Y|N|Y|N
+|namespace|Y|N|Y|N
+|namespaces|Y|Y|Y|Y
+|acl|Y|N|Y|N
+|sentinel|Y|N|Y|N
+
+## Development
+* create virtualenv and activate
+* install requirements-dev.txt
+* can either use the Vagrantfile for local integration testing or create environment variables `NOMAD_IP` and `NOMAD_PORT` that are assigned to a nomad binary that is running
+
+```
+virutalenv venv
+source venv/bin/activate
+pip install -r requirements-dev.txt
+```
+
+## Testing with vagrant and virtualbox
+```
+vagrant up --provider virtualbox
+py.test --cov=nomad --cov-report=term-missing --runxfail tests/
+```

--- a/example_batch_parameterized.json
+++ b/example_batch_parameterized.json
@@ -61,10 +61,6 @@
                     "Mode": "delay"
                 }
             }
-        ],
-        "Update": {
-            "Stagger": 0,
-            "MaxParallel": 0
-        }
+        ]
     }
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,6 +18,7 @@ pages:
    - Evaluation: 'api/evaluation.md'
    - Job: 'api/job.md'
    - Jobs: 'api/jobs.md'
+   - Metrics: 'api/metrics.md'
    - Node: 'api/node.md'
    - Nodes: 'api/nodes.md'
    - Regions: 'api/regions.md'

--- a/nomad/api/exceptions.py
+++ b/nomad/api/exceptions.py
@@ -17,4 +17,4 @@ class URLNotAuthorizedNomadException(Exception):
 
 
 class InvalidParameters(Exception):
-    """This method cannot have both parameters enable"""
+    """Invalid parameters given"""

--- a/nomad/api/exceptions.py
+++ b/nomad/api/exceptions.py
@@ -14,3 +14,7 @@ class URLNotAuthorizedNomadException(Exception):
     """The requested URL is not authorized. ACL"""
     def __init__(self, nomad_resp):
         self.nomad_resp = nomad_resp
+
+
+class InvalidParameters(Exception):
+    """This method cannot have both parameters enable"""

--- a/nomad/api/node.py
+++ b/nomad/api/node.py
@@ -119,11 +119,13 @@ class Node(object):
         return self._post(id, "drain", enable={"enable": enable})
 
     def drain_node_with_spec(self, id, drain_spec, mark_eligible=None):
-        """ Drain the node.
-            When enabled, no further allocations will be
-            assigned and existing allocations will be migrated.
+        """ This endpoint toggles the drain mode of the node. When draining is enabled,
+            no further allocations will be assigned to this node, and existing allocations
+            will be migrated to new nodes.
 
-           https://www.nomadproject.io/docs/http/node.html
+            If an empty dictionary is given as drain_spec this will disable/toggle the drain.
+
+            https://www.nomadproject.io/docs/http/node.html
 
             arguments:
               - id (str uuid): node id
@@ -150,7 +152,13 @@ class Node(object):
         elif not drain_spec and mark_eligible is not None:
             payload = {
                 "NodeID": id,
+                "DrainSpec": None,
                 "MarkEligible": mark_eligible
+            }
+        elif not drain_spec and mark_eligible is None:
+            payload = {
+                "NodeID": id,
+                "DrainSpec": None,
             }
 
         return self._post(id, "drain", payload=payload)

--- a/nomad/api/node.py
+++ b/nomad/api/node.py
@@ -80,7 +80,7 @@ class Node(object):
         url = self._requester._endpointBuilder(Node.ENDPOINT, *args)
 
         if kwargs:
-            response = self._requester.post(url, params=kwargs["enable"])
+            response = self._requester.post(url, params=kwargs.get("enable", None), json=kwargs.get("payload", {}))
         else:
             response = self._requester.post(url)
 
@@ -107,9 +107,88 @@ class Node(object):
 
            https://www.nomadproject.io/docs/http/node.html
 
+            arguments:
+              - id (str uuid): node id
+              - enable (bool): enable node drain or not to enable node drain
             returns: dict
             raises:
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
+
         return self._post(id, "drain", enable={"enable": enable})
+
+    def drain_node_with_spec(self, id, drain_spec, mark_eligible=None):
+        """ Drain the node.
+            When enabled, no further allocations will be
+            assigned and existing allocations will be migrated.
+
+           https://www.nomadproject.io/docs/http/node.html
+
+            arguments:
+              - id (str uuid): node id
+              - drain_spec (dict): https://www.nomadproject.io/api/nodes.html#drainspec
+              - mark_eligible (bool): https://www.nomadproject.io/api/nodes.html#markeligible
+            returns: dict
+            raises:
+              - nomad.api.exceptions.BaseNomadException
+              - nomad.api.exceptions.URLNotFoundNomadException
+        """
+        payload = {}
+
+        if drain_spec and mark_eligible is not None:
+            payload = {
+                "NodeID": id,
+                "DrainSpec": drain_spec,
+                "MarkEligible": mark_eligible
+            }
+        elif drain_spec and mark_eligible is None:
+            payload = {
+                "NodeID": id,
+                "DrainSpec": drain_spec
+            }
+        elif not drain_spec and mark_eligible is not None:
+            payload = {
+                "NodeID": id,
+                "MarkEligible": mark_eligible
+            }
+
+        return self._post(id, "drain", payload=payload)
+
+    def eligible_node(self, id, eligible=None, ineligible=None):
+        """ Toggle the eligibility of the node.
+
+           https://www.nomadproject.io/docs/http/node.html
+
+            arguments:
+              - id (str uuid): node id
+              - eligible (bool): Set to True to mark node eligible
+              - ineligible (bool): Set to True to mark node ineligible
+            returns: dict
+            raises:
+              - nomad.api.exceptions.BaseNomadException
+              - nomad.api.exceptions.URLNotFoundNomadException
+        """
+        payload = {}
+
+        if eligible is not None and ineligible is not None:
+            raise nomad.api.exceptions.InvalidParameters
+        elif eligible:
+            payload = {"Eligibility": "eligible", "NodeID": id}
+        elif ineligible:
+            payload = {"Eligibility": "ineligible", "NodeID": id}
+
+        return self._post(id, "eligibility", payload=payload)
+
+    def purge_node(self, id):
+        """
+        arguments:
+          - id (str uuid): node id
+        returns: dict
+        raises:
+          - nomad.api.exceptions.BaseNomadException
+          - nomad.api.exceptions.URLNotFoundNomadException
+        """
+
+        return self._post(id, "purge")
+

--- a/nomad/api/node.py
+++ b/nomad/api/node.py
@@ -196,7 +196,7 @@ class Node(object):
         return self._post(id, "eligibility", payload=payload)
 
     def purge_node(self, id):
-        """
+        """ This endpoint purges a node from the system. Nodes can still join the cluster if they are alive.
         arguments:
           - id (str uuid): node id
         returns: dict

--- a/nomad/api/node.py
+++ b/nomad/api/node.py
@@ -173,10 +173,17 @@ class Node(object):
 
         if eligible is not None and ineligible is not None:
             raise nomad.api.exceptions.InvalidParameters
-        elif eligible:
+        if eligible is None and ineligible is None:
+            raise nomad.api.exceptions.InvalidParameters
+
+        if eligible is not None and eligible:
             payload = {"Eligibility": "eligible", "NodeID": id}
-        elif ineligible:
+        elif eligible is not None and not eligible:
             payload = {"Eligibility": "ineligible", "NodeID": id}
+        elif ineligible is not None:
+            payload = {"Eligibility": "ineligible", "NodeID": id}
+        elif ineligible is not None and not ineligible:
+            payload = {"Eligibility": "eligible", "NodeID": id}
 
         return self._post(id, "eligibility", payload=payload)
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='python-nomad',
-    version='0.7.0',
+    version='0.8.0',
     install_requires=['requests'],
     packages=['nomad', 'nomad.api'],
     url='http://github.com/jrxfive/python-nomad',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+import nomad
+import pytest
+import tests.common as common
+
+@pytest.fixture
+def nomad_setup():
+    n = nomad.Nomad(host=common.IP, port=common.NOMAD_PORT, verify=False, token=common.NOMAD_TOKEN)
+    return n

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -1,16 +1,8 @@
 import pytest
 import tests.common as common
-import nomad
 import json
 import os
-from nomad.api import exceptions
 
-
-
-@pytest.fixture
-def nomad_setup():
-    n = nomad.Nomad(host=common.IP, port=common.NOMAD_PORT,token=common.NOMAD_TOKEN, verify=False)
-    return n
 
 # integration tests requires nomad Vagrant VM or Binary running
 # IMPORTANT: without token activated

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -39,7 +39,7 @@ def test_join_agent(nomad_setup):
     assert r["num_joined"] == 0
 
 
-@pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 3, 2), reason="Not supported in version")
+@pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 4, 1), reason="Not supported in version")
 def test_update_servers(nomad_setup):
     known_servers = nomad_setup.agent.get_servers()
     r = nomad_setup.agent.update_servers(known_servers)

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -39,6 +39,7 @@ def test_join_agent(nomad_setup):
     assert r["num_joined"] == 0
 
 
+@pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 3, 2), reason="Not supported in version")
 def test_update_servers(nomad_setup):
     known_servers = nomad_setup.agent.get_servers()
     r = nomad_setup.agent.update_servers(known_servers)

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1,19 +1,9 @@
 import pytest
-import tests.common as common
-import nomad
 import os
 from nomad.api import exceptions as nomad_exceptions
-import json
 
-
-@pytest.fixture
-def nomad_setup():
-    n = nomad.Nomad(host=common.IP, port=common.NOMAD_PORT, verify=False, token=common.NOMAD_TOKEN)
-    return n
 
 # integration tests requires nomad Vagrant VM or Binary running
-
-
 def test_get_agent(nomad_setup):
     assert isinstance(nomad_setup.agent.get_agent(), dict) == True
 

--- a/tests/test_allocation.py
+++ b/tests/test_allocation.py
@@ -1,18 +1,8 @@
 import pytest
-import tests.common as common
-import nomad
 import json
-import requests
 
-
-@pytest.fixture
-def nomad_setup():
-    n = nomad.Nomad(host=common.IP, port=common.NOMAD_PORT, verify=False, token=common.NOMAD_TOKEN)
-    return n
 
 # integration tests requires nomad Vagrant VM or Binary running
-
-
 def test_register_job(nomad_setup):
 
     with open("example.json") as fh:

--- a/tests/test_allocations.py
+++ b/tests/test_allocations.py
@@ -1,16 +1,7 @@
 import pytest
-import tests.common as common
-import nomad
 
-
-@pytest.fixture
-def nomad_setup():
-    n = nomad.Nomad(host=common.IP, port=common.NOMAD_PORT, verify=False, token=common.NOMAD_TOKEN)
-    return n
 
 # integration tests requires nomad Vagrant VM or Binary running
-
-
 def test_get_allocations(nomad_setup):
     assert isinstance(nomad_setup.allocations.get_allocations(), list) == True
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,14 +1,8 @@
 import pytest
 import tests.common as common
 import nomad
-from nomad.api import exceptions
 import os
 import requests_mock
-
-@pytest.fixture
-def nomad_setup():
-    n = nomad.Nomad(host=common.IP, port=common.NOMAD_PORT, verify=False, token=common.NOMAD_TOKEN)
-    return n
 
 
 # integration tests requires nomad Vagrant VM or Binary running
@@ -39,6 +33,7 @@ def test_base_get_connnection_not_authorized():
         host=common.IP, port=common.NOMAD_PORT, token='aed2fc63-c155-40d5-b58a-18deed4b73e5', verify=False)
     with pytest.raises(nomad.api.exceptions.URLNotAuthorizedNomadException):
         j = n.job.get_job("example")
+
 
 def test_base_use_address_instead_on_host_port():
     with requests_mock.Mocker() as m:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,16 +1,5 @@
 import pytest
-import tests.common as common
-import nomad
 import json
-import time
-import requests
-
-
-@pytest.fixture
-def nomad_setup():
-    n = nomad.Nomad(host=common.IP, port=common.NOMAD_PORT, verify=False, token=common.NOMAD_TOKEN)
-    return n
-
 
 # integration tests requires nomad Vagrant VM or Binary running
 def test_register_job(nomad_setup):

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -1,16 +1,8 @@
 import pytest
-import tests.common as common
 import os
 import nomad
 
-
-@pytest.fixture
-def nomad_setup():
-    n = nomad.Nomad(host=common.IP, port=common.NOMAD_PORT, verify=False, token=common.NOMAD_TOKEN)
-    return n
-
 # integration tests requires nomad Vagrant VM or Binary running
-
 @pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 6, 0), reason="Not supported in version")
 def test_get_deployment(nomad_setup):
     deploymentID = nomad_setup.deployments.get_deployments()[0]["ID"]

--- a/tests/test_deployments.py
+++ b/tests/test_deployments.py
@@ -1,19 +1,12 @@
 import pytest
-import tests.common as common
 import os
-import nomad
 
-
-@pytest.fixture
-def nomad_setup():
-    n = nomad.Nomad(host=common.IP, port=common.NOMAD_PORT, verify=False, token=common.NOMAD_TOKEN)
-    return n
 
 # integration tests requires nomad Vagrant VM or Binary running
-
 @pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 6, 0), reason="Not supported in version")
 def test_get_evaluation(nomad_setup):
     assert "example" == nomad_setup.deployments.get_deployments()[0]["JobID"]
+
 
 @pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 6, 0), reason="Not supported in version")
 def test_dunder_getitem_exist(nomad_setup):
@@ -21,23 +14,28 @@ def test_dunder_getitem_exist(nomad_setup):
     d = nomad_setup.deployment[jobID]
     assert isinstance(d, dict)
 
+
 @pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 6, 0), reason="Not supported in version")
 def test_dunder_getitem_not_exist(nomad_setup):
     with pytest.raises(KeyError):
         _ = nomad_setup.deployments["nope"]
+
 
 @pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 6, 0), reason="Not supported in version")
 def test_dunder_contain_exists(nomad_setup):
     jobID = nomad_setup.deployments.get_deployments()[0]["ID"]
     assert jobID in nomad_setup.deployments
 
+
 @pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 6, 0), reason="Not supported in version")
 def test_dunder_contain_not_exist(nomad_setup):
     assert "nope" not in nomad_setup.deployments
 
+
 @pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 6, 0), reason="Not supported in version")
 def test_dunder_len(nomad_setup):
     assert len(nomad_setup.deployments) == 1
+
 
 @pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 6, 0), reason="Not supported in version")
 def test_dunder_iter(nomad_setup):

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -1,16 +1,7 @@
 import pytest
-import tests.common as common
-import nomad
 
-
-@pytest.fixture
-def nomad_setup():
-    n = nomad.Nomad(host=common.IP, port=common.NOMAD_PORT, verify=False, token=common.NOMAD_TOKEN)
-    return n
 
 # integration tests requires nomad Vagrant VM or Binary running
-
-
 def test_get_evaluation(nomad_setup):
     evalID = nomad_setup.job.get_allocations("example")[0]["EvalID"]
     assert isinstance(

--- a/tests/test_evaluations.py
+++ b/tests/test_evaluations.py
@@ -1,12 +1,4 @@
 import pytest
-import tests.common as common
-import nomad
-
-
-@pytest.fixture
-def nomad_setup():
-    n = nomad.Nomad(host=common.IP, port=common.NOMAD_PORT, verify=False, token=common.NOMAD_TOKEN)
-    return n
 
 
 # integration tests requires nomad Vagrant VM or Binary running

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -1,19 +1,11 @@
 import pytest
-import tests.common as common
 import nomad
 import json
 import os
 from nomad.api import exceptions
 
 
-@pytest.fixture
-def nomad_setup():
-    n = nomad.Nomad(host=common.IP, port=common.NOMAD_PORT, verify=False, token=common.NOMAD_TOKEN)
-    return n
-
 # integration tests requires nomad Vagrant VM or Binary running
-
-
 def test_register_job(nomad_setup):
 
     with open("example.json") as fh:

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1,14 +1,5 @@
 import pytest
-import tests.common as common
-import nomad
 import json
-import requests
-
-
-@pytest.fixture
-def nomad_setup():
-    n = nomad.Nomad(host=common.IP, port=common.NOMAD_PORT, verify=False, token=common.NOMAD_TOKEN)
-    return n
 
 
 # integration tests requires nomad Vagrant VM or Binary running

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,22 @@
+import pytest
+import os
+
+
+# integration tests requires nomad Vagrant VM or Binary running
+@pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 7, 1), reason="Not supported in version")
+def test_metrics(nomad_setup):
+    nomad_setup.metrics.get_metrics()
+
+
+def test_dunder_str(nomad_setup):
+    assert isinstance(str(nomad_setup.metrics), str)
+
+
+def test_dunder_repr(nomad_setup):
+    assert isinstance(repr(nomad_setup.metrics), str)
+
+
+def test_dunder_getattr(nomad_setup):
+
+    with pytest.raises(AttributeError):
+        d = nomad_setup.metrics.does_not_exist

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -1,21 +1,10 @@
-import pytest
-import tests.common as common
-import nomad
 import json
-from nomad.api import exceptions
 from mock import patch, MagicMock
 import requests
 
 
 
-@pytest.fixture
-def nomad_setup():
-    n = nomad.Nomad(host=common.IP, port=common.NOMAD_PORT, verify=False, token=common.NOMAD_TOKEN)
-    return n
-
 # integration tests was mocked. If you have an enterprise nomad please uncomenet ##### ENTERPRISE TEST #####
-
-
 @patch('nomad.api.namespace.Namespace._post')
 def test_create_namespace(mock_post, nomad_setup):
     mock_post.return_value = requests.codes.ok

--- a/tests/test_namespaces.py
+++ b/tests/test_namespaces.py
@@ -1,20 +1,7 @@
-import pytest
-import tests.common as common
-import nomad
-import json
-from nomad.api import exceptions
 from mock import patch, MagicMock
 
 
-
-@pytest.fixture
-def nomad_setup():
-    n = nomad.Nomad(host=common.IP, port=common.NOMAD_PORT, verify=False, token=common.NOMAD_TOKEN)
-    return n
-
-
 # integration tests was mocked. If you have an enterprise nomad please uncomenet ##### ENTERPRISE TEST #####
-
 @patch('nomad.api.namespaces.Namespaces._get')
 def test_get_namespaces(mock_get, nomad_setup):
     mock_get.return_value = [

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -35,23 +35,24 @@ def test_drain_node(nomad_setup):
     nodeID = nomad_setup.nodes["pynomad1"]["ID"]
     assert "EvalIDs" in nomad_setup.node.drain_node(nodeID)
     assert "EvalIDs" in nomad_setup.node.drain_node(nodeID, True)
-    assert nomad_setup.node[nodeID]["Drain"] == True
+    assert nomad_setup.node[nodeID]["Drain"] is True
     nomad_setup.node.drain_node(nodeID)
-    assert nomad_setup.node[nodeID]["Drain"] == False
+    assert nomad_setup.node[nodeID]["Drain"] is False
 
 
 @pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 8, 1), reason="Not supported in version")
 def test_drain_node_with_spec(nomad_setup):
     nodeID = nomad_setup.nodes["pynomad1"]["ID"]
     assert "EvalIDs" in nomad_setup.node.drain_node_with_spec(nodeID, drain_spec={"Duration": "-100000000"})
-    assert nomad_setup.node[nodeID]["Drain"] == True
-    assert "EvalIDs" in nomad_setup.node.drain_node_with_spec(nodeID, drain_spec={"Duration": "-100000000"}, mark_eligible=True)
-    assert nomad_setup.node[nodeID]["Drain"] == False
+    assert nomad_setup.node[nodeID]["Drain"] is True
+    assert "EvalIDs" in nomad_setup.node.drain_node_with_spec(nodeID, drain_spec={}, mark_eligible=True)
+    assert nomad_setup.node[nodeID]["Drain"] is False
 
 
 @pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 8, 1), reason="Not supported in version")
 def test_eligible_node(nomad_setup):
     nodeID = nomad_setup.nodes["pynomad1"]["ID"]
+
     nomad_setup.node.eligible_node(nodeID, ineligible=True)
     assert nomad_setup.node[nodeID]["SchedulingEligibility"] == "ineligible"
 
@@ -63,6 +64,7 @@ def test_eligible_node(nomad_setup):
 
     with pytest.raises(nomad_exceptions.InvalidParameters):
         assert nomad_setup.node.eligible_node(nodeID)
+
 
 def test_dunder_getitem_exist(nomad_setup):
     nodeID = nomad_setup.nodes["pynomad1"]["ID"]

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -1,19 +1,9 @@
 import os
 import pytest
-import tests.common as common
-import nomad
 from nomad.api import exceptions as nomad_exceptions
-import json
 
-
-@pytest.fixture
-def nomad_setup():
-    n = nomad.Nomad(host=common.IP, port=common.NOMAD_PORT, verify=False, token=common.NOMAD_TOKEN)
-    return n
 
 # integration tests requires nomad Vagrant VM or Binary running
-
-
 def test_get_node(nomad_setup):
     nodeID = nomad_setup.nodes["pynomad1"]["ID"]
     assert isinstance(nomad_setup.node.get_node(nodeID), dict) == True

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -1,12 +1,4 @@
 import pytest
-import tests.common as common
-import nomad
-
-
-@pytest.fixture
-def nomad_setup():
-    n = nomad.Nomad(host=common.IP, port=common.NOMAD_PORT, verify=False, token=common.NOMAD_TOKEN)
-    return n
 
 
 # integration tests requires nomad Vagrant VM or Binary running

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -1,36 +1,32 @@
 import pytest
-import tests.common as common
-import nomad
-import json
 import os
-import mock
 from nomad.api import exceptions
 
-
-@pytest.fixture
-def nomad_setup():
-    n = nomad.Nomad(host=common.IP, port=common.NOMAD_PORT, verify=False, token=common.NOMAD_TOKEN)
-    return n
 
 # integration tests requires nomad Vagrant VM or Binary running
 @pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 5, 5), reason="Not supported in version")
 def test_get_configuration_default(nomad_setup):
     assert isinstance(nomad_setup.operator.get_configuration(), dict)
 
+
 @pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 5, 5), reason="Not supported in version")
 def test_get_configuration_stale(nomad_setup):
     assert isinstance(nomad_setup.operator.get_configuration(stale=True), dict)
+
 
 @pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 5, 5), reason="Not supported in version")
 def test_delete_peer(nomad_setup):
     with pytest.raises(exceptions.URLNotFoundNomadException):
         nomad_setup.operator.delete_peer("192.168.33.10:4646")
 
+
 def test_dunder_str(nomad_setup):
     assert isinstance(str(nomad_setup.operator), str)
 
+
 def test_dunder_repr(nomad_setup):
     assert isinstance(repr(nomad_setup.operator), str)
+
 
 def test_dunder_getattr(nomad_setup):
     with pytest.raises(AttributeError):

--- a/tests/test_regions.py
+++ b/tests/test_regions.py
@@ -1,13 +1,5 @@
 import pytest
-import tests.common as common
-import nomad
 import sys
-
-
-@pytest.fixture
-def nomad_setup():
-    n = nomad.Nomad(host=common.IP, port=common.NOMAD_PORT, verify=False, token=common.NOMAD_TOKEN)
-    return n
 
 
 # integration tests requires nomad Vagrant VM or Binary running

--- a/tests/test_sentinel.py
+++ b/tests/test_sentinel.py
@@ -1,20 +1,9 @@
-import pytest
-import tests.common as common
-import nomad
 import json
-from nomad.api import exceptions
 from mock import patch, MagicMock
 import requests
 
 
-
-@pytest.fixture
-def nomad_setup():
-    n = nomad.Nomad(host=common.IP, port=common.NOMAD_PORT, verify=False, token=common.NOMAD_TOKEN)
-    return n
-
 # integration tests was mocked.
-
 @patch('nomad.api.sentinel.Sentinel._get')
 def test_list_policies(mock_get, nomad_setup):
     mock_get.return_value = [

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -1,13 +1,6 @@
 import pytest
 import tests.common as common
-import nomad
 import sys
-
-
-@pytest.fixture
-def nomad_setup():
-    n = nomad.Nomad(host=common.IP, port=common.NOMAD_PORT, verify=False, token=common.NOMAD_TOKEN)
-    return n
 
 
 # integration tests requires nomad Vagrant VM or Binary running

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -1,13 +1,4 @@
 import pytest
-import tests.common as common
-import nomad
-import requests
-
-
-@pytest.fixture
-def nomad_setup():
-    n = nomad.Nomad(host=common.IP, port=common.NOMAD_PORT, verify=False, token=common.NOMAD_TOKEN)
-    return n
 
 
 # integration tests requires nomad Vagrant VM or Binary running

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,14 +1,7 @@
 import pytest
 import os
-import tests.common as common
 import nomad
 import json
-
-
-@pytest.fixture
-def nomad_setup():
-    n = nomad.Nomad(host=common.IP, port=common.NOMAD_PORT, verify=False, token=common.NOMAD_TOKEN)
-    return n
 
 
 # integration tests requires nomad Vagrant VM or Binary running
@@ -17,11 +10,13 @@ def test_validate_job(nomad_setup):
     with open("example.json") as job:
         nomad_setup.validate.validate_job(json.loads(job.read()))
 
+
 # integration tests requires nomad Vagrant VM or Binary running
 @pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 6, 0), reason="Not supported in version")
 def test_invalid_job(nomad_setup):
     with pytest.raises(nomad.api.exceptions.URLNotFoundNomadException):
         nomad_setup.validate.validate_job({})
+
 
 def test_dunder_str(nomad_setup):
     assert isinstance(str(nomad_setup.validate), str)


### PR DESCRIPTION
Support for:

- node drain with drain_spec
- node eligibility
- purge node

Tests:
add tests for metrics

Update documentation for node and jobs. Consolidate pytest fixtures in conftest.py