### PR TITLE
Add new parse endpoint that parses hcl into json job files.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ env:
   - NOMAD_VERSION="0.6.0"
   - NOMAD_VERSION="0.7.1"
   - NOMAD_VERSION="0.8.1"
+  - NOMAD_VERSION="0.8.3"
 before_install:
 - curl -L -o /tmp/nomad_${NOMAD_VERSION}_linux_amd64.zip https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}_linux_amd64.zip
 - yes | unzip -d /tmp /tmp/nomad_${NOMAD_VERSION}_linux_amd64.zip

--- a/nomad/api/jobs.py
+++ b/nomad/api/jobs.py
@@ -100,3 +100,17 @@ class Jobs(object):
               - nomad.api.exceptions.URLNotFoundNomadException
         """
         return self._post(job=job)
+
+
+    def parse(self, hcl, canonicalize=False):
+        """ Parse a HCL Job file. Returns a dict with the JSON formatted job.
+            This API endpoint is only supported from Nomad version 0.8.3.
+
+            https://www.nomadproject.io/api/jobs.html#parse-job
+
+            returns: dict
+            raises:
+              - nomad.api.exceptions.BaseNomadException
+              - nomad.api.exceptions.URLNotFoundNomadException
+        """
+        return self._post("parse", job={"JobHCL": hcl, "Canonicalize": canonicalize})

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 import json
 
@@ -13,6 +14,16 @@ def test_register_job(nomad_setup):
         job = json.loads(fh.read())
         nomad_setup.jobs.register_job(job)
         assert "example" in nomad_setup.jobs
+
+
+@pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 8, 3), reason="Not supported in version")
+def test_parse_job(nomad_setup):
+
+    with open("example.nomad") as fh:
+        hcl = fh.read()
+        json_dict = nomad_setup.jobs.parse(hcl)
+        assert json_dict["Name"] == "example"
+        assert json_dict["Type"] == "service"
 
 
 def test_dunder_getitem_exist(nomad_setup):


### PR DESCRIPTION
Version 0.8.3 added this new route:
https://www.nomadproject.io/api/jobs.html#parse-job