### PR TITLE
Put "Diff" parameter into the request body

### DIFF
--- a/nomad/api/job.py
+++ b/nomad/api/job.py
@@ -203,7 +203,10 @@ class Job(object):
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self._post(id, "plan", json_dict=job, params={"diff": diff})
+        json_dict = {}
+        json_dict.update(job)
+        json_dict["Diff"] = diff
+        return self._post(id, "plan", json_dict=json_dict)
 
     def periodic_job(self, id):
         """ Forces a new instance of the periodic job. A new instance will be


### PR DESCRIPTION
As explained in #60, the _Diff_ parameter should be in the request payload rather than a GET parameter. This change puts it into the payload. A different dictionary is constructed for the payload to avoid unexpectedly modifying the passed in dictionary.