### PR TITLE
Feature: Vault integration with allow_unantenticated = false

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,8 @@
 .vagrant
 .build
 .venv
+example.json
+example.hcl
+vault.hcl
+vault.json
+example.nomad

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ env:
   global:
   - NOMAD_IP="127.0.0.1"
   - NOMAD_PORT="4646"
+  - VAULT_VERSION="0.9.0"
+  - VAULT_ADDR="http://127.0.0.1:8200"
   matrix:
   - NOMAD_VERSION="0.3.2"
   - NOMAD_VERSION="0.4.1"
@@ -30,19 +32,14 @@ env:
   - NOMAD_VERSION="0.7.1"
   - NOMAD_VERSION="0.8.1"
   - NOMAD_VERSION="0.8.3"
-before_install:
-- curl -L -o /tmp/nomad_${NOMAD_VERSION}_linux_amd64.zip https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}_linux_amd64.zip
-- yes | unzip -d /tmp /tmp/nomad_${NOMAD_VERSION}_linux_amd64.zip
-- MAJOR_VERSION=`echo ${NOMAD_VERSION} | cut -d "." -f 2`
-- if [[ ${MAJOR_VERSION} -gt 6 ]]; then echo "Nomad version $NOMAD_VERSION supports acls";export ACL_ENABLED="--acl-enabled"; else echo "Nomad version $NOMAD_VERSION";export ACL_ENABLED="";  fi
-- /tmp/nomad agent -dev -bind ${NOMAD_IP} -node pynomad1 ${ACL_ENABLED} > /dev/null 2>&1 &
-- sleep 30
+  - NOMAD_VERSION="0.8.4"
+  - NOMAD_VERSION="0.8.5"
+  - NOMAD_VERSION="0.8.6"
 install:
 - pip install -r requirements-dev.txt
 - pip install codecov
 before_script:
-  - /tmp/nomad init
-  - /tmp/nomad run -output example.nomad > example.json
+  - sudo ./travis_before_script.sh
 script:
 - py.test --cov=nomad --cov-report=term-missing --runxfail tests/
 after_success:

--- a/README.md
+++ b/README.md
@@ -58,6 +58,18 @@ NOMAD_TOKEN=xxxx-xxxx-xxxx-xxxx
 NOMAD_REGION=us-east-1a
 ```
 
+## Vault integration
+
+if you have configured a [Vault Integration ](https://www.nomadproject.io/docs/configuration/vault.html) to store your secrets.
+
+And you have configured: [`allow_unantenticated = false`](https://www.nomadproject.io/docs/configuration/vault.html#allow_unauthenticated)
+see  you must to export and send a valid `VAULT_TOKEN`.
+
+```bash
+VAULT_TOKEN=xxxx-xxxx-xxxx-xxxx
+```
+
+
 ## Class Dunders
 
 | Class | contains | len | getitem | iter |
@@ -90,14 +102,15 @@ NOMAD_REGION=us-east-1a
 * can either use the Vagrantfile for local integration testing or create environment variables `NOMAD_IP` and `NOMAD_PORT` that are assigned to a nomad binary that is running
 
 ```
-virutalenv venv
-source venv/bin/activate
+virutalenv .venv
+source .venv/bin/activate
 pip install -r requirements-dev.txt
 ```
 
 ## Testing with vagrant and virtualbox
 ```
 vagrant up --provider virtualbox
+create_sample_jobs.sh
 py.test --cov=nomad --cov-report=term-missing --runxfail tests/
 ```
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,18 +1,24 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-IP = "192.168.33.10"
-NOMAD_VERSION = "0.7.1"
-NOMAD_PORT_GUEST = 4646
-NOMAD_PORT_HOST = 4646
+NOMAD_IP="192.168.33.10"
+NOMAD_VERSION="0.8.6"
+NOMAD_PORT_GUEST=4646
+NOMAD_PORT_HOST=4646
+VAULT_VERSION="0.9.0"
+VAULT_PORT_GUEST=8200
+VAULT_PORT_HOST=8200
+VAULT_ADDR="http://127.0.0.1:8200"
+
 
 Vagrant.configure(2) do |config|
 
 config.vm.box = "centos/7"
 
 config.vm.network "forwarded_port", guest: NOMAD_PORT_GUEST, host: NOMAD_PORT_HOST
+config.vm.network "forwarded_port", guest: VAULT_PORT_GUEST, host: VAULT_PORT_HOST
 
-config.vm.network "private_network", ip: "#{IP}"
+config.vm.network "private_network", ip: "#{NOMAD_IP}"
 
 config.vm.provider "virtualbox" do |vb|
 vb.name = "python-nomad"
@@ -22,8 +28,7 @@ end
 
 config.vm.provision "shell", inline: <<-SHELL
 
-if [ ! -e /etc/yum.repos.d/docker.repo ]
-  then
+if [ ! -e /etc/yum.repos.d/docker.repo ]; then
 tee /etc/yum.repos.d/docker.repo <<-EOF
 [dockerrepo]
 name=Docker Repository
@@ -38,22 +43,127 @@ yum -y install docker-engine unzip wget net-tools
 usermod -aG docker vagrant
 systemctl enable docker; systemctl start docker
 
+echo "pip for test inside the vagrant"
+curl "https://bootstrap.pypa.io/get-pip.py" -o "get-pip.py"
+python get-pip.py
+pip install -r /vagrant/requirements-dev.txt
+
+
+echo "Download binary files"
 wget -q -P /tmp/ https://releases.hashicorp.com/nomad/#{NOMAD_VERSION}/nomad_#{NOMAD_VERSION}_linux_amd64.zip
 yes | unzip -d /tmp /tmp/nomad_#{NOMAD_VERSION}_linux_amd64.zip
 
+wget -q -P /tmp/ https://releases.hashicorp.com/vault/#{VAULT_VERSION}/vault_#{VAULT_VERSION}_linux_amd64.zip
+yes | unzip -d /tmp /tmp/vault_#{VAULT_VERSION}_linux_amd64.zip
+
+echo "Copy binary"
 if [ ! -f /usr/bin/nomad ]
-  then
+then
     cp /tmp/nomad /usr/bin/.
 fi
 
-if [ $(pgrep nomad) ]
-  then
-    echo "Nomad running"
-  else
-    echo "Starting Nomad"
-    nohup nomad agent -dev -bind #{IP} -node pynomad1 --acl-enabled > /dev/null 2>&1 &
-    sleep 30
+if [ ! -f /usr/bin/vault ]
+then
+    cp /tmp/vault /usr/bin/.
 fi
+
+MAJOR_VERSION=`echo #{NOMAD_VERSION} | cut -d "." -f 2`
+
+echo "Vault: Create policy file"
+cat << EOF > /tmp/policy-demo.hcl
+path "secret/demo" {
+    capabilities = ["read"]
+}
+EOF
+
+echo "Vault: Start Daemon"
+/usr/bin/vault server -dev -dev-listen-address=0.0.0.0:8200 -dev-root-token-id="root" > /var/log/vault.log 2>&1 &
+sleep 5
+
+echo "Vault: Write Vault Policies"
+VAULT_TOKEN=root vault policy-write -address=http://127.0.0.1:8200 policy-demo /tmp/policy-demo.hcl
+
+echo "Vault: Write Vault Secret"
+VAULT_TOKEN=root vault write -address=http://127.0.0.1:8200 secret/demo data=python_nomad
+
+echo "Nomad: Create config folder"
+mkdir -p /etc/nomad.d
+
+if [[ ${MAJOR_VERSION} -gt 7 ]]; then
+echo "Nomad: Enable Config Vault"
+cat << EOF > /etc/nomad.d/vault.hcl
+vault
+{
+  enabled     = true
+  address     = "#{VAULT_ADDR}"
+  token = "root"
+  allow_unauthenticated = false
+}
+EOF
+fi
+
+echo "Nomad: Config base"
+cat << EOF > /etc/nomad.d/base_config.hcl
+datacenter = "dc1"
+name = "pynomad1"
+bind_addr = "#{NOMAD_IP}"
+client
+{
+    enabled = true
+    node_class = "default"
+}
+ports
+{
+  http = #{NOMAD_PORT_GUEST}
+  rpc  = 4647
+}
+addresses
+{
+  http = "#{NOMAD_IP}"
+  rpc = "#{NOMAD_IP}"
+}
+advertise
+{
+  http = "#{NOMAD_IP}:#{NOMAD_PORT_GUEST}"
+  rpc = "#{NOMAD_IP}:4647"
+}
+log_level = "INFO"
+enable_debug = false
+EOF
+
+echo "Nomad: Config Server"
+cat << EOF > /etc/nomad.d/server.hcl
+server
+{
+  enabled = true
+  bootstrap_expect = 1
+}
+EOF
+
+if [[ ${MAJOR_VERSION} -gt 6 ]]; then
+  echo "Nomad: version #{NOMAD_VERSION} supports acls"
+  echo "Nomad: Config ACL"
+cat << EOF > /etc/nomad.d/acl.hcl
+acl
+{
+  enabled = true
+  token_ttl = "30s"
+  policy_ttl = "60s"
+}
+EOF
+else
+  echo "Nomad: version #{NOMAD_VERSION}"
+fi
+
+echo "Nomad: Create test job samples"
+/usr/bin/nomad init
+/usr/bin/nomad run -output example.nomad > example.json
+echo "Starting Nomad"
+nohup nomad agent -server -dev -config=/etc/nomad.d > /dev/null 2>&1 &
+sleep 30
+
+
+echo "You can execute your test!"
 
 SHELL
 

--- a/create_sample_jobs.sh
+++ b/create_sample_jobs.sh
@@ -1,0 +1,8 @@
+echo "Nomad: Create test job samples"
+/usr/bin/nomad init
+/usr/bin/nomad run -output example.nomad > example.json
+cp example.nomad vault.hcl
+sed -i s/"# vault {"/"vault { policies = [\"policy-demo\"]}"/g vault.hcl
+sed -i s/"job \"example\" {"/"job \"vault\" {"/g vault.hcl
+/usr/bin/nomad run -output vault.hcl > vault.json
+

--- a/nomad/__init__.py
+++ b/nomad/__init__.py
@@ -4,17 +4,18 @@ import os
 
 class Nomad(object):
 
-    def __init__(self, 
-        host='127.0.0.1', 
-        secure=False, 
+    def __init__(self,
+        host='127.0.0.1',
+        secure=False,
         port=4646,
         address=os.getenv('NOMAD_ADDR', None),
         namespace=os.getenv('NOMAD_NAMESPACE', None),
-        token=os.getenv('NOMAD_TOKEN', None), 
-        timeout=5, 
-        region=os.getenv('NOMAD_REGION', None), 
-        version='v1', 
-        verify=False, 
+        token=os.getenv('NOMAD_TOKEN', None),
+        vaulttoken=os.getenv('VAULT_TOKEN', None),
+        timeout=5,
+        region=os.getenv('NOMAD_REGION', None),
+        version='v1',
+        verify=False,
         cert=()):
         """ Nomad api client
 
@@ -35,6 +36,9 @@ class Nomad(object):
                                 be use to deploy or to ask info to nomad.
             - token (defaults to None), Specifies to append ACL token to the headers to
                                 make authentication on secured based nomad environemnts.
+            - vaulttoken (defaults to None), Specifies to append ACL token to the headers to
+                                make authentication on environemnts with allow_unantenticated = false, where
+                                you must to send a valid vault token for policies.
            returns: Nomad api client object
 
            raises:
@@ -52,7 +56,7 @@ class Nomad(object):
         self.cert = cert
 
         self.requester = api.Requester(address=address, uri=self.get_uri(), port=port, namespace=namespace,
-                                        token=token, timeout=timeout, version=version, verify=verify, cert=cert, region = region)
+                                        token=token, vaulttoken=vaulttoken, timeout=timeout, version=version, verify=verify, cert=cert, region = region)
 
         self._jobs = api.Jobs(self.requester)
         self._job = api.Job(self.requester)
@@ -83,11 +87,17 @@ class Nomad(object):
     def set_token(self, token):
         self.requester.token = token
 
+    def set_vaulttoken(self, vaulttoken):
+        self.requester.vaulttoken = vaulttoken
+
     def get_namespace(self):
         return self.requester.namespace
 
     def get_token(self):
         return self.requester.token
+
+    def get_vaulttoken(self):
+        return self.requester.vaulttoken
 
     def get_uri(self):
         if self.secure:

--- a/nomad/api/base.py
+++ b/nomad/api/base.py
@@ -7,11 +7,12 @@ requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
 class Requester(object):
 
-    def __init__(self, address=None, uri='http://127.0.0.1', port=4646, namespace=None, token=None, timeout=5, version='v1', verify=False, cert=(), region=None):
+    def __init__(self, address=None, uri='http://127.0.0.1', port=4646, namespace=None, token=None, vaulttoken=None, timeout=5, version='v1', verify=False, cert=(), region=None):
         self.uri = uri
         self.port = port
         self.namespace = namespace
         self.token = token
+        self.vaulttoken = vaulttoken
         self.timeout = timeout
         self.version = version
         self.verify = verify
@@ -104,6 +105,11 @@ class Requester(object):
                 headers["X-Nomad-Token"] = self.token
             except TypeError:
                 headers = { "X-Nomad-Token": self.token }
+        if json:
+            if self.vaulttoken:
+                if "Job" in json:
+                    json["Job"]["VaultToken"] = self.vaulttoken
+
         response = None
 
         try:
@@ -131,6 +137,7 @@ class Requester(object):
                 headers["X-Nomad-Token"] = self.token
             except TypeError:
                 headers = { "X-Nomad-Token": self.token }
+
         response = None
 
         try:

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 
 # internal ip of docker
 IP = os.environ.get("NOMAD_IP", "192.168.33.10")
@@ -9,3 +10,16 @@ NOMAD_PORT = os.environ.get("NOMAD_PORT", 4646)
 
 # Security token
 NOMAD_TOKEN = os.environ.get("NOMAD_TOKEN", None)
+
+# Security token
+VAULT_TOKEN = os.environ.get("VAULT_TOKEN", "root")
+VAULT_ADDR = os.environ.get("VAULT_ADDR", "http://" + IP + ":8200")
+
+vaultEnvironment = {"VAULT_TOKEN":"root","VAULT_ADDR":VAULT_ADDR}
+p = subprocess.Popen("/tmp/vault token-create -policy=policy-demo|grep 'token '|awk '{print $2}'|tr -d '\n'", stdout=subprocess.PIPE, shell=True, env=vaultEnvironment)
+(vaulttoken, err) = p.communicate()
+p_status = p.wait()
+print("\n SecurityVaultAcl: {}\n".format(vaulttoken.decode('utf-8')))
+
+VAULT_POLICY_TOKEN=vaulttoken.decode('utf-8')
+VAULT_POLICY_INVALID_TOKEN = '1a77d23a-01f9-d848-8457-08bcec267c65'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,5 +4,15 @@ import tests.common as common
 
 @pytest.fixture
 def nomad_setup():
-    n = nomad.Nomad(host=common.IP, port=common.NOMAD_PORT, verify=False, token=common.NOMAD_TOKEN)
+    n = nomad.Nomad(host=common.IP, port=common.NOMAD_PORT, verify=False, token=common.NOMAD_TOKEN, vaulttoken=common.VAULT_TOKEN)
+    return n
+
+@pytest.fixture
+def nomad_setup_vault_valid_token():
+    n = nomad.Nomad(host=common.IP, port=common.NOMAD_PORT, verify=False, token=common.NOMAD_TOKEN, vaulttoken=common.VAULT_POLICY_TOKEN)
+    return n
+
+@pytest.fixture
+def nomad_setup_vault_invalid_token():
+    n = nomad.Nomad(host=common.IP, port=common.NOMAD_PORT, verify=False, token=common.NOMAD_TOKEN, vaulttoken=common.VAULT_POLICY_INVALID_TOKEN)
     return n

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -13,6 +13,9 @@ def test_create_bootstrap(nomad_setup):
     bootstrap = nomad_setup.acl.generate_bootstrap()
     assert "SecretID" in bootstrap
     common.NOMAD_TOKEN = bootstrap["SecretID"]
+    # For debug at vagrant you should use -s at test to view the token
+    # py.test -s --cov=nomad --cov-report=term-missing --runxfail tests/
+    print("\n SecurityNomadRootToken: {}\n".format(common.NOMAD_TOKEN))
 
 @pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 7, 0), reason="Nomad dispatch not supported")
 @pytest.mark.run(order=1)

--- a/tests/test_vault_integration.py
+++ b/tests/test_vault_integration.py
@@ -1,0 +1,42 @@
+import pytest
+import nomad
+import json
+import os
+from nomad.api import exceptions
+
+
+# # integration tests requires nomad Vagrant VM or Binary running
+# Specific token for this policy
+@pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 8, 0) or tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) == (0,8,5), reason="Not supported in version. At version 0.8.5 see regresion of 8.5.6 at https://github.com/hashicorp/nomad/blob/master/CHANGELOG.md")
+@pytest.mark.run(order=-1)
+def test_register_job_valid(nomad_setup_vault_valid_token):
+    with open("vault.json") as fh:
+        job = json.loads(fh.read())
+        nomad_setup_vault_valid_token.job.register_job("vault", job)
+        assert "vault" in nomad_setup_vault_valid_token.job
+
+
+# Specific token for this policy
+@pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 8, 0) or tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) == (0,8,5), reason="Not supported in version. At version 0.8.5 see regresion of 8.5.6 at https://github.com/hashicorp/nomad/blob/master/CHANGELOG.md")
+@pytest.mark.run(order=-2)
+def test_get_job_valid(nomad_setup_vault_valid_token):
+    assert isinstance(nomad_setup_vault_valid_token.job.get_job("vault"), dict) == True
+
+
+# Specific token for this policy
+@pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 8, 0) or tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) == (0,8,5), reason="Not supported in version. At version 0.8.5 see regresion of 8.5.6 at https://github.com/hashicorp/nomad/blob/master/CHANGELOG.md")
+@pytest.mark.run(order=-3)
+def test_delete_job_valid(nomad_setup):
+    assert "EvalID" in nomad_setup.job.deregister_job("vault")
+
+
+# Specific BAD token for this policy
+# test non valid token for deploy
+@pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 8, 0) or tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) == (0,8,5), reason="Not supported in version. At version 0.8.5 see regresion of 8.5.6 at https://github.com/hashicorp/nomad/blob/master/CHANGELOG.md")
+@pytest.mark.run(order=-4)
+def test_register_job_invalid(nomad_setup_vault_invalid_token):
+    with open("vault.json") as fh:
+        job = json.loads(fh.read())
+
+        with pytest.raises(nomad.api.exceptions.URLNotFoundNomadException):
+            nomad_setup_vault_invalid_token.job.register_job("vault", job)

--- a/travis_before_script.sh
+++ b/travis_before_script.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+
+echo "Get Binary Files"
+wget -q -P /tmp/ https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}_linux_amd64.zip
+yes | unzip -d /tmp /tmp/nomad_${NOMAD_VERSION}_linux_amd64.zip
+
+wget -q -P /tmp/ https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip
+yes | unzip -d /tmp /tmp/vault_${VAULT_VERSION}_linux_amd64.zip
+
+echo "Copy binary"
+if [ ! -f /usr/bin/nomad ]
+then
+    cp /tmp/nomad /usr/bin/.
+fi
+
+if [ ! -f /usr/bin/vault ]
+then
+    cp /tmp/vault /usr/bin/.
+fi
+
+MAJOR_VERSION=`echo ${NOMAD_VERSION} | cut -d "." -f 2`
+
+echo "Vault: Create policy file"
+cat << EOF > /tmp/policy-demo.hcl
+path "secret/demo" {
+    capabilities = ["read"]
+}
+EOF
+
+echo "Vault: Start Daemon"
+/usr/bin/vault server -dev -dev-listen-address=0.0.0.0:8200 -dev-root-token-id="root" > /var/log/vault.log 2>&1 &
+sleep 5
+
+echo "Vault: Write Vault Policies"
+VAULT_TOKEN=root vault policy-write -address=http://127.0.0.1:8200 policy-demo /tmp/policy-demo.hcl
+
+echo "Vault: Write Vault Secret"
+VAULT_TOKEN=root vault write -address=http://127.0.0.1:8200 secret/demo data=python_nomad
+
+echo "Nomad: Create config folder"
+mkdir -p /etc/nomad.d
+
+if [[ ${MAJOR_VERSION} -gt 7 ]]; then
+echo "Nomad: Enable Config Vault"
+cat << EOF > /etc/nomad.d/vault.hcl
+vault
+{
+  enabled     = true
+  address     = "${VAULT_ADDR}"
+  token = "root"
+  allow_unauthenticated = false
+}
+EOF
+fi
+
+echo "Nomad: Config base"
+cat << EOF > /etc/nomad.d/base_config.hcl
+datacenter = "dc1"
+name = "pynomad1"
+bind_addr = "${NOMAD_IP}"
+client
+{
+    enabled = true
+    node_class = "default"
+}
+ports
+{
+  http = ${NOMAD_PORT}
+  rpc  = 4647
+}
+addresses
+{
+  http = "${NOMAD_IP}"
+  rpc = "${NOMAD_IP}"
+}
+advertise
+{
+  http = "${NOMAD_IP}:${NOMAD_PORT}"
+  rpc = "${NOMAD_IP}:4647"
+}
+log_level = "INFO"
+enable_debug = false
+EOF
+
+echo "Nomad: Config Server"
+cat << EOF > /etc/nomad.d/server.hcl
+server
+{
+  enabled = true
+  bootstrap_expect = 1
+}
+EOF
+
+if [[ ${MAJOR_VERSION} -gt 6 ]]; then
+echo "Nomad version $NOMAD_VERSION supports acls"
+echo "Nomad: Config ACL"
+cat << EOF > /etc/nomad.d/acl.hcl
+acl
+{
+  enabled = true
+  token_ttl = "30s"
+  policy_ttl = "60s"
+}
+EOF
+else
+  echo "Nomad: version $NOMAD_VERSION"
+fi
+
+echo "Nomad: Create test job samples"
+/usr/bin/nomad init
+/usr/bin/nomad run -output example.nomad > example.json
+if [[ ${MAJOR_VERSION} -ge 8 ]]; then
+  cp example.nomad vault.hcl
+  sed -i s/"# vault {"/"vault { policies = [\"policy-demo\"]}"/g vault.hcl
+  sed -i s/"job \"example\" {"/"job \"vault\" {"/g vault.hcl
+  /usr/bin/nomad run -output vault.hcl > vault.json
+fi
+chmod 777 example* vault.*
+
+
+echo "Starting Nomad"
+nohup nomad agent -server -dev -config=/etc/nomad.d > /dev/null 2>&1 &
+sleep 30
+
+echo "You can execute your test! ENJOY!"


### PR DESCRIPTION
Nomad could use Vault (https://www.nomadproject.io/docs/configuration/vault.html) as a secret store.
If you wish to use it secure, you should configure the parameter allow_unantenticated = False, to force to give a NOMAD_TOKEN to hadle the NOMAD Acl, and a VAULT_TOKEN with rights over the policy that you have configurated at your job.

https://www.nomadproject.io/docs/job-specification/vault.html

I have made several changes at vagrant and travis to make the test.

Please, take a look

Regards