### PR TITLE
Base Requester and Exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 Branch | Status | Coverage |
 ---| ---| ---
-develop | [![Build Status](https://travis-ci.org/jrxFive/python-nomad.svg?branch=develop)](https://travis-ci.org/jrxFive/python-nomad) | [![codecov](https://codecov.io/gh/jrxFive/python-nomad/branch/develop/graph/badge.svg)](https://codecov.io/gh/jrxFive/python-nomad)
+master | [![Build Status](https://travis-ci.org/jrxFive/python-nomad.svg?branch=master)](https://travis-ci.org/jrxFive/python-nomad) | [![codecov](https://codecov.io/gh/jrxFive/python-nomad/branch/master/graph/badge.svg)](https://codecov.io/gh/jrxFive/python-nomad)
 
 
 ## Installation

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,7 +2,7 @@
 # vi: set ft=ruby :
 
 IP = "192.168.33.10"
-NOMAD_VERSION = "0.7.1"
+NOMAD_VERSION = "0.8.3"
 NOMAD_PORT_GUEST = 4646
 NOMAD_PORT_HOST = 4646
 

--- a/docs/api/jobs.md
+++ b/docs/api/jobs.md
@@ -122,3 +122,146 @@ my_nomad = nomad.Nomad(host='192.168.33.10')
 
 response = my_nomad.jobs.register_job(job)
 ```
+
+
+### Parse Job
+To convert to python dict and verify for correctness a hcl/nomad file. The example will use "example.nomad" when running
+`nomad job init` and it will assume this file is in the current working directory. In practice this file should already
+be read and used as the parameter hcl.
+
+https://www.nomadproject.io/api/jobs.html#parse-job
+
+```python
+
+import nomad
+
+nomad_client = nomad.Nomad()
+
+with open("example.nomad", "r") as fh:
+    try:
+        job_raw_nomad = fh.read()
+        job_dict = nomad_client.jobs.parse(job_raw_nomad)
+    except nomad.api.exceptions.BadRequestNomadException as err:
+        print(err.nomad_resp.reason)
+        print(err.nomad_resp.text)
+```
+
+On success of example.nomad being successfully parsed job_dict will have:
+
+```python
+{'AllAtOnce': None,
+ 'Constraints': None,
+ 'CreateIndex': None,
+ 'Datacenters': ['dc1'],
+ 'Dispatched': False,
+ 'ID': 'example',
+ 'JobModifyIndex': None,
+ 'Meta': None,
+ 'Migrate': {'HealthCheck': 'checks',
+             'HealthyDeadline': 300000000000,
+             'MaxParallel': 1,
+             'MinHealthyTime': 10000000000},
+ 'ModifyIndex': None,
+ 'Name': 'example',
+ 'Namespace': None,
+ 'ParameterizedJob': None,
+ 'ParentID': None,
+ 'Payload': None,
+ 'Periodic': None,
+ 'Priority': None,
+ 'Region': None,
+ 'Reschedule': None,
+ 'Stable': None,
+ 'Status': None,
+ 'StatusDescription': None,
+ 'Stop': None,
+ 'SubmitTime': None,
+ 'TaskGroups': [{'Constraints': None,
+                 'Count': 1,
+                 'EphemeralDisk': {'Migrate': None,
+                                   'SizeMB': 300,
+                                   'Sticky': None},
+                 'Meta': None,
+                 'Migrate': None,
+                 'Name': 'cache',
+                 'ReschedulePolicy': None,
+                 'RestartPolicy': {'Attempts': 2,
+                                   'Delay': 15000000000,
+                                   'Interval': 1800000000000,
+                                   'Mode': 'fail'},
+                 'Tasks': [{'Artifacts': None,
+                            'Config': {'image': 'redis:3.2',
+                                       'port_map': [{'db': 6379}]},
+                            'Constraints': None,
+                            'DispatchPayload': None,
+                            'Driver': 'docker',
+                            'Env': None,
+                            'KillSignal': '',
+                            'KillTimeout': None,
+                            'Leader': False,
+                            'LogConfig': None,
+                            'Meta': None,
+                            'Name': 'redis',
+                            'Resources': {'CPU': 500,
+                                          'DiskMB': None,
+                                          'IOPS': None,
+                                          'MemoryMB': 256,
+                                          'Networks': [{'CIDR': '',
+                                                        'Device': '',
+                                                        'DynamicPorts': [{'Label': 'db',
+                                                                          'Value': 0}],
+                                                        'IP': '',
+                                                        'MBits': 10,
+                                                        'ReservedPorts': None}]},
+                            'Services': [{'AddressMode': '',
+                                          'CanaryTags': None,
+                                          'CheckRestart': None,
+                                          'Checks': [{'AddressMode': '',
+                                                      'Args': None,
+                                                      'CheckRestart': None,
+                                                      'Command': '',
+                                                      'GRPCService': '',
+                                                      'GRPCUseTLS': False,
+                                                      'Header': None,
+                                                      'Id': '',
+                                                      'InitialStatus': '',
+                                                      'Interval': 10000000000,
+                                                      'Method': '',
+                                                      'Name': 'alive',
+                                                      'Path': '',
+                                                      'PortLabel': '',
+                                                      'Protocol': '',
+                                                      'TLSSkipVerify': False,
+                                                      'Timeout': 2000000000,
+                                                      'Type': 'tcp'}],
+                                          'Id': '',
+                                          'Name': 'redis-cache',
+                                          'PortLabel': 'db',
+                                          'Tags': ['global', 'cache']}],
+                            'ShutdownDelay': 0,
+                            'Templates': None,
+                            'User': '',
+                            'Vault': None}],
+                 'Update': None}],
+ 'Type': 'service',
+ 'Update': {'AutoRevert': False,
+            'Canary': 0,
+            'HealthCheck': None,
+            'HealthyDeadline': 180000000000,
+            'MaxParallel': 1,
+            'MinHealthyTime': 10000000000,
+            'ProgressDeadline': None,
+            'Stagger': None},
+ 'VaultToken': None,
+ 'Version': None}
+```
+
+On failure it will raise `BadRequestNomadException` we can inspect the requests response:
+```
+>>> err.nomad_resp.reason
+'Bad Request'
+
+err.nomad_resp.text
+"error parsing 'job': 1 error(s) occurred:\n\n* job: invalid key: datacenter"
+
+```

--- a/nomad/__init__.py
+++ b/nomad/__init__.py
@@ -98,7 +98,7 @@ class Nomad(object):
         return "{protocol}://{host}".format(protocol=protocol, host=self.host)
 
     def get_namespace(self):
-        return self.namespace
+        return self.__namespace
 
     def get_token(self):
         return self.token

--- a/nomad/__init__.py
+++ b/nomad/__init__.py
@@ -46,48 +46,49 @@ class Nomad(object):
         self.secure = secure
         self.port = port
         self.address = address
+        self.region = region
         self.timeout = timeout
         self.version = version
+        self.token = token
         self.verify = verify
         self.cert = cert
+        self.__namespace = namespace
 
-        self.requester = api.Requester(address=address, uri=self.get_uri(), port=port, namespace=namespace,
-                                        token=token, timeout=timeout, version=version, verify=verify, cert=cert, region = region)
+        self.requester_settings = {
+            "address": self.address,
+            "uri": self.get_uri(),
+            "port": self.port,
+            "namespace": self.__namespace,
+            "token": self.token,
+            "timeout": self.timeout,
+            "version": self.version,
+            "verify": self.verify,
+            "cert": self.cert,
+            "region": self.region
+        }
 
-        self._jobs = api.Jobs(self.requester)
-        self._job = api.Job(self.requester)
-        self._nodes = api.Nodes(self.requester)
-        self._node = api.Node(self.requester)
-        self._allocations = api.Allocations(self.requester)
-        self._allocation = api.Allocation(self.requester)
-        self._evaluations = api.Evaluations(self.requester)
-        self._evaluation = api.Evaluation(self.requester)
-        self._agent = api.Agent(self.requester)
-        self._client = api.Client(self.requester)
-        self._deployments = api.Deployments(self.requester)
-        self._deployment = api.Deployment(self.requester)
-        self._regions = api.Regions(self.requester)
-        self._status = api.Status(self.requester)
-        self._system = api.System(self.requester)
-        self._operator = api.Operator(self.requester)
-        self._validate = api.Validate(self.requester)
-        self._namespaces = api.Namespaces(self.requester)
-        self._namespace = api.Namespace(self.requester)
-        self._acl = api.Acl(self.requester)
-        self._sentinel = api.Sentinel(self.requester)
-        self._metrics = api.Metrics(self.requester)
-
-    def set_namespace(self, namespace):
-        self.requester.namespace = namespace
-
-    def set_token(self, token):
-        self.requester.token = token
-
-    def get_namespace(self):
-        return self.requester.namespace
-
-    def get_token(self):
-        return self.requester.token
+        self._jobs = api.Jobs(**self.requester_settings)
+        self._job = api.Job(**self.requester_settings)
+        self._nodes = api.Nodes(**self.requester_settings)
+        self._node = api.Node(**self.requester_settings)
+        self._allocations = api.Allocations(**self.requester_settings)
+        self._allocation = api.Allocation(**self.requester_settings)
+        self._evaluations = api.Evaluations(**self.requester_settings)
+        self._evaluation = api.Evaluation(**self.requester_settings)
+        self._agent = api.Agent(**self.requester_settings)
+        self._client = api.Client(**self.requester_settings)
+        self._deployments = api.Deployments(**self.requester_settings)
+        self._deployment = api.Deployment(**self.requester_settings)
+        self._regions = api.Regions(**self.requester_settings)
+        self._status = api.Status(**self.requester_settings)
+        self._system = api.System(**self.requester_settings)
+        self._operator = api.Operator(**self.requester_settings)
+        self._validate = api.Validate(**self.requester_settings)
+        self._namespaces = api.Namespaces(**self.requester_settings)
+        self._namespace = api.Namespace(**self.requester_settings)
+        self._acl = api.Acl(**self.requester_settings)
+        self._sentinel = api.Sentinel(**self.requester_settings)
+        self._metrics = api.Metrics(**self.requester_settings)
 
     def get_uri(self):
         if self.secure:
@@ -95,6 +96,12 @@ class Nomad(object):
         else:
             protocol = "http"
         return "{protocol}://{host}".format(protocol=protocol, host=self.host)
+
+    def get_namespace(self):
+        return self.namespace
+
+    def get_token(self):
+        return self.token
 
     @property
     def jobs(self):

--- a/nomad/api/acl.py
+++ b/nomad/api/acl.py
@@ -97,7 +97,7 @@ class Acl(Requester):
 
             https://www.nomadproject.io/api/acl-tokens.html
 
-            returns: dict
+            returns: Boolean
 
             raises:
               - nomad.api.exceptions.BaseNomadException
@@ -185,6 +185,7 @@ class Acl(Requester):
 
             arguments:
                 - id
+            returns: Boolean
 
             raises:
               - nomad.api.exceptions.BaseNomadException

--- a/nomad/api/acl.py
+++ b/nomad/api/acl.py
@@ -1,7 +1,9 @@
 import nomad.api.exceptions
 
+from nomad.api.base import Requester
 
-class Acl(object):
+
+class Acl(Requester):
     """
     The endpoint manage security ACL and tokens
 
@@ -10,8 +12,8 @@ class Acl(object):
 
     ENDPOINT = "acl"
 
-    def __init__(self, requester):
-        self._requester = requester
+    def __init__(self, **kwargs):
+        super(Acl, self).__init__(**kwargs)
 
     def __str__(self):
         return "{0}".format(self.__dict__)
@@ -21,38 +23,6 @@ class Acl(object):
 
     def __getattr__(self, item):
         raise AttributeError
-
-    def _get(self, *args, **kwargs):
-        url = self._requester._endpointBuilder(Acl.ENDPOINT, *args)
-        response = self._requester.get(url,
-                                       params=kwargs.get("params", None))
-
-        return response.json()
-
-    def _post(self, *args, **kwargs):
-        url = self._requester._endpointBuilder(Acl.ENDPOINT, *args)
-        if kwargs:
-            response = self._requester.post(url, json=kwargs.get("json_dict", None), params=kwargs.get("params", None))
-        else:
-            response = self._requester.post(url)
-
-        return response.json()
-
-    def _post_no_json(self, *args, **kwargs):
-        url = self._requester._endpointBuilder(Acl.ENDPOINT, *args)
-        if kwargs:
-            response = self._requester.post(url, json=kwargs.get("json_dict", None), params=kwargs.get("params", None))
-        else:
-            response = self._requester.post(url)
-
-        return response
-
-    def _delete(self, *args, **kwargs):
-        url = self._requester._endpointBuilder(Acl.ENDPOINT, *args)
-        response = self._requester.delete(url,
-                                          params=kwargs.get("params", None))
-
-        return response.ok
 
     def generate_bootstrap(self):
         """ Activate bootstrap token.
@@ -65,8 +35,7 @@ class Acl(object):
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-
-        return self._post("bootstrap")
+        return self.request("bootstrap", method="post").json()
 
     def get_tokens(self):
         """ Get a list of tokens.
@@ -79,7 +48,8 @@ class Acl(object):
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self._get("tokens")
+
+        return self.request("tokens", method="get").json()
 
     def get_token(self, id):
         """ Retrieve specific token.
@@ -92,7 +62,7 @@ class Acl(object):
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self._get("token", id)
+        return self.request("token", id, method="get").json()
 
     def get_self_token(self):
         """ Retrieve self token used for auth.
@@ -105,7 +75,7 @@ class Acl(object):
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self._get("token", "self")
+        return self.request("token", "self", method="get").json()
 
     def create_token(self, token):
         """ Create token.
@@ -120,7 +90,7 @@ class Acl(object):
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self._post("token", json_dict=token)
+        return self.request("token", json=token, method="post").json()
 
     def delete_token(self, id):
         """ Delete specific token.
@@ -133,7 +103,7 @@ class Acl(object):
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self._delete("token", id)
+        return self.request("token", id, method="delete").ok
 
     def update_token(self, id, token):
         """ Update token.
@@ -149,7 +119,7 @@ class Acl(object):
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self._post("token", id, json_dict=token)
+        return self.request("token", id, json=token, method="post").json()
 
     def get_policies(self):
         """ Get a list of policies.
@@ -162,7 +132,7 @@ class Acl(object):
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self._get("policies")
+        return self.request("policies", method="get").json()
 
     def create_policy(self, id, policy):
         """ Create policy.
@@ -171,13 +141,13 @@ class Acl(object):
 
             arguments:
                 - policy
-            returns: dict
+            returns: request.Response
 
             raises:
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self._post_no_json("policy", id, json_dict=policy)
+        return self.request("policy", id, json=policy, method="post")
 
     def get_policy(self, id):
         """ Get a spacific.
@@ -190,7 +160,7 @@ class Acl(object):
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self._get("policy", id)
+        return self.request("policy", id, method="get").json()
 
     def update_policy(self, id, policy):
         """ Create policy.
@@ -200,13 +170,13 @@ class Acl(object):
             arguments:
                 - name
                 - policy
-            returns: dict
+            returns: request.Response
 
             raises:
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self._post_no_json("policy", id, json_dict=policy)
+        return self.request("policy", id, json=policy, method="post")
 
     def delete_policy(self, id):
         """ Delete specific policy.
@@ -220,4 +190,4 @@ class Acl(object):
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self._delete("policy", id)
+        return self.request("policy", id, method="delete").ok

--- a/nomad/api/agent.py
+++ b/nomad/api/agent.py
@@ -67,7 +67,7 @@ class Agent(Requester):
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        params = "address=" + "&address=".join(addresses)
+        params = {"address": addresses}
         return self.request("join", params=params, method="post").json()
 
     def update_servers(self, addresses):
@@ -81,7 +81,7 @@ class Agent(Requester):
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        params = "address=" + "&address=".join(addresses)
+        params = {"address": addresses}
         return self.request("servers", params=params, method="post").status_code
 
     def force_leave(self, node):
@@ -94,5 +94,5 @@ class Agent(Requester):
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        params = "node={node}".format(node=node)
+        params = {"node": node}
         return self.request("force-leave", params=params, method="post").status_code

--- a/nomad/api/agent.py
+++ b/nomad/api/agent.py
@@ -1,13 +1,15 @@
 import nomad.api.exceptions
 
+from nomad.api.base import Requester
 
-class Agent(object):
+
+class Agent(Requester):
 
     """The self endpoint is used to query the state of the target agent."""
     ENDPOINT = "agent"
 
-    def __init__(self, requester):
-        self._requester = requester
+    def __init__(self, **kwargs):
+        super(Agent, self).__init__(**kwargs)
 
     def __str__(self):
         return "{0}".format(self.__dict__)
@@ -19,12 +21,6 @@ class Agent(object):
         msg = "{0} does not exist".format(item)
         raise AttributeError(msg)
 
-    def _get(self, *args):
-        url = self._requester._endpointBuilder(Agent.ENDPOINT, *args)
-        agent = self._requester.get(url)
-
-        return agent.json()
-
     def get_agent(self):
         """ Query the state of the target agent.
 
@@ -35,7 +31,7 @@ class Agent(object):
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self._get("self")
+        return self.request("self", method="get").json()
 
     def get_members(self):
         """Lists the known members of the gossip pool.
@@ -47,7 +43,7 @@ class Agent(object):
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self._get("members")
+        return self.request("members", method="get").json()
 
     def get_servers(self):
         """ Lists the known members of the gossip pool.
@@ -59,17 +55,7 @@ class Agent(object):
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self._get("servers")
-
-    def _post(self, *args, **kwargs):
-        try:
-            url = self._requester._endpointBuilder(Agent.ENDPOINT, *args)
-
-            response = self._requester.post(url, params=kwargs["params"])
-
-            return response.json()
-        except ValueError:
-            return response.status_code
+        return self.request("servers", method="get").json()
 
     def join_agent(self, addresses):
         """Initiate a join between the agent and target peers.
@@ -82,7 +68,7 @@ class Agent(object):
               - nomad.api.exceptions.URLNotFoundNomadException
         """
         params = "address=" + "&address=".join(addresses)
-        return self._post("join", params=params)
+        return self.request("join", params=params, method="post").json()
 
     def update_servers(self, addresses):
         """Updates the list of known servers to the provided list.
@@ -96,7 +82,7 @@ class Agent(object):
               - nomad.api.exceptions.URLNotFoundNomadException
         """
         params = "address=" + "&address=".join(addresses)
-        return self._post("servers", params=params)
+        return self.request("servers", params=params, method="post").status_code
 
     def force_leave(self, node):
         """Force a failed gossip member into the left state.
@@ -109,4 +95,4 @@ class Agent(object):
               - nomad.api.exceptions.URLNotFoundNomadException
         """
         params = "node={node}".format(node=node)
-        return self._post("force-leave", params=params)
+        return self.request("force-leave", params=params, method="post").status_code

--- a/nomad/api/allocation.py
+++ b/nomad/api/allocation.py
@@ -1,7 +1,9 @@
 import nomad.api.exceptions
 
+from nomad.api.base import Requester
 
-class Allocation(object):
+
+class Allocation(Requester):
     """
     The allocation endpoint is used to query the a specific allocation.
     By default, the agent's local region is used; another region can be
@@ -12,8 +14,8 @@ class Allocation(object):
 
     ENDPOINT = "allocation"
 
-    def __init__(self, requester):
-        self._requester = requester
+    def __init__(self, **kwargs):
+        super(Allocation, self).__init__(**kwargs)
 
     def __str__(self):
         return "{0}".format(self.__dict__)
@@ -26,7 +28,7 @@ class Allocation(object):
 
     def __contains__(self, item):
         try:
-            response = self._get(item)
+            response = self.get_allocation(item)
 
             if response["ID"] == item:
                 return True
@@ -35,18 +37,12 @@ class Allocation(object):
 
     def __getitem__(self, item):
         try:
-            response = self._get(item)
+            response = self.get_allocation(item)
 
             if response["ID"] == item:
                 return response
         except nomad.api.exceptions.URLNotFoundNomadException:
             raise KeyError
-
-    def _get(self, *args):
-        url = self._requester._endpointBuilder(Allocation.ENDPOINT, *args)
-        response = self._requester.get(url)
-
-        return response.json()
 
     def get_allocation(self, id):
         """ Query a specific allocation.
@@ -58,4 +54,4 @@ class Allocation(object):
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self._get(id)
+        return self.request(id, method="get").json()

--- a/nomad/api/allocations.py
+++ b/nomad/api/allocations.py
@@ -1,5 +1,7 @@
+from nomad.api.base import Requester
 
-class Allocations(object):
+
+class Allocations(Requester):
 
     """
     The allocations endpoint is used to query the status of allocations.
@@ -10,8 +12,8 @@ class Allocations(object):
     """
     ENDPOINT = "allocations"
 
-    def __init__(self, requester):
-        self._requester = requester
+    def __init__(self, **kwargs):
+        super(Allocations, self).__init__(**kwargs)
 
     def __str__(self):
         return "{0}".format(self.__dict__)
@@ -23,18 +25,12 @@ class Allocations(object):
         raise AttributeError
 
     def __len__(self):
-        response = self._get()
+        response = self.get_allocations()
         return len(response)
 
     def __iter__(self):
-        response = self._get()
+        response = self.get_allocations()
         return iter(response)
-
-    def _get(self, *args):
-        url = self._requester._endpointBuilder(Allocations.ENDPOINT, *args)
-        response = self._requester.get(url)
-
-        return response.json()
 
     def get_allocations(self):
         """ Lists all the allocations.
@@ -46,4 +42,4 @@ class Allocations(object):
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self._get()
+        return self.request(method="get").json()

--- a/nomad/api/base.py
+++ b/nomad/api/base.py
@@ -5,9 +5,12 @@ from requests.packages.urllib3.exceptions import InsecureRequestWarning
 
 requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
+
 class Requester(object):
 
-    def __init__(self, address=None, uri='http://127.0.0.1', port=4646, namespace=None, token=None, timeout=5, version='v1', verify=False, cert=(), region=None):
+    ENDPOINT = ""
+
+    def __init__(self, address=None, uri='http://127.0.0.1', port=4646, namespace=None, token=None, timeout=5, version='v1', verify=False, cert=(), region=None, **kwargs):
         self.uri = uri
         self.port = port
         self.namespace = namespace
@@ -69,108 +72,87 @@ class Requester(object):
                 region=self.region)
         return url
 
+    def request(self, *args, **kwargs):
+        endpoint = self._endpointBuilder(self.ENDPOINT, *args)
+        response = self._request(
+            endpoint=endpoint,
+            method=kwargs.get("method"),
+            params=kwargs.get("params", None),
+            data=kwargs.get("data", None),
+            json=kwargs.get("json", None),
+            headers=kwargs.get("headers", None),
+            allow_redirects=kwargs.get("allow_redirects", False)
+        )
 
-    def get(self, endpoint, params=None, headers=None):
+        return response
+
+    def _request(self, method, endpoint, params=None, data=None, json=None, headers=None, allow_redirects=None):
         url = self._urlBuilder(endpoint)
+
         if self.token:
             try:
                 headers["X-Nomad-Token"] = self.token
             except TypeError:
-                headers = { "X-Nomad-Token": self.token }
+                headers = {"X-Nomad-Token": self.token}
+
         response = None
 
         try:
-            response = self.session.get(url,
-                                        headers=headers,
-                                        params=params,
-                                        verify=self.verify,
-                                        cert=self.cert,
-                                        timeout=self.timeout)
+            method = method.lower()
+            if method == "get":
+                response = self.session.get(
+                    url=url,
+                    params=params,
+                    headers=headers,
+                    timeout=self.timeout,
+                    verify=self.verify,
+                    cert=self.cert,
+                    allow_redirects=allow_redirects
+                )
+
+            elif method == "post":
+                response = self.session.post(
+                    url=url,
+                    params=params,
+                    json=json,
+                    headers=headers,
+                    data=data,
+                    timeout=self.timeout,
+                    verify=self.verify,
+                    cert=self.cert,
+                    allow_redirects=allow_redirects
+                )
+            elif method == "put":
+                response = self.session.put(
+                    url=url,
+                    params=params,
+                    json=json,
+                    headers=headers,
+                    data=data,
+                    verify=self.verify,
+                    cert=self.cert,
+                    timeout=self.timeout
+                )
+            elif method == "delete":
+                response = self.session.delete(
+                    url=url,
+                    params=params,
+                    headers=headers,
+                    verify=self.verify,
+                    cert=self.cert,
+                    timeout=self.timeout
+                )
 
             if response.ok:
                 return response
-            if response.status_code == 400 or response.status_code == 404 or response.status_code == 500:
-                raise nomad.api.exceptions.URLNotFoundNomadException(response)
-            if response.status_code == 403:
+            elif response.status_code == 400:
+                raise nomad.api.exceptions.BadRequestNomadException(response)
+            elif response.status_code == 403:
                 raise nomad.api.exceptions.URLNotAuthorizedNomadException(response)
-
-        except requests.RequestException:
-            raise nomad.api.exceptions.BaseNomadException(response)
-
-    def post(self, endpoint, params=None, data=None, json=None, headers=None):
-        url = self._urlBuilder(endpoint)
-        if self.token:
-            try:
-                headers["X-Nomad-Token"] = self.token
-            except TypeError:
-                headers = { "X-Nomad-Token": self.token }
-        response = None
-
-        try:
-            response = self.session.post(url,
-                                         params=params,
-                                         json=json,
-                                         headers=headers,
-                                         data=data,
-                                         verify=self.verify,
-                                         cert=self.cert,
-                                         timeout=self.timeout)
-
-            if response.ok:
-                return response
-            if response.status_code == 400 or response.status_code == 404 or response.status_code == 500:
+            elif response.status_code == 404:
                 raise nomad.api.exceptions.URLNotFoundNomadException(response)
-
-        except requests.RequestException:
-            raise nomad.api.exceptions.BaseNomadException(response)
-
-    def put(self, endpoint, params=None, data=None, headers=None):
-        url = self._urlBuilder(endpoint)
-        if self.token:
-            try:
-                headers["X-Nomad-Token"] = self.token
-            except TypeError:
-                headers = { "X-Nomad-Token": self.token }
-        response = None
-
-        try:
-            response = self.session.put(url,
-                                        params=params,
-                                        headers=headers,
-                                        data=data,
-                                        verify=self.verify,
-                                        cert=self.cert,
-                                        timeout=self.timeout)
-
-            if response.ok:
-                return response
-            if response.status_code == 400 or response.status_code == 404 or response.status_code == 500:
-                raise nomad.api.exceptions.URLNotFoundNomadException(response)
-
-        except requests.RequestException:
-            raise nomad.api.exceptions.BaseNomadException(response)
-
-    def delete(self, endpoint, params=None, headers=None):
-        url = self._urlBuilder(endpoint)
-        if self.token:
-            try:
-                headers["X-Nomad-Token"] = self.token
-            except TypeError:
-                headers = { "X-Nomad-Token": self.token }
-        response = None
-
-        try:
-            response = self.session.delete(url,
-                                           params=params,
-                                           headers=headers,
-                                           verify=self.verify,
-                                           cert=self.cert,
-                                           timeout=self.timeout)
-
-            if response.ok:
-                return response
-            if response.status_code == 400 or response.status_code == 404 or response.status_code == 500:
-                raise nomad.api.exceptions.URLNotFoundNomadException(response)
+            else:
+                raise nomad.api.exceptions.BaseNomadException(response)
 
         except requests.RequestException:
             raise nomad.api.exceptions.BaseNomadException(response)

--- a/nomad/api/base.py
+++ b/nomad/api/base.py
@@ -46,6 +46,7 @@ class Requester(object):
             required = endpoint_split[ENDPOINT_NAME] in required_namespace
         except:
             required = False
+
         return required
 
     def _url_builder(self, endpoint):
@@ -88,7 +89,9 @@ class Requester(object):
         qs = self._query_string_builder(endpoint)
 
         if params:
-            params.update(qs)
+            qs.update(params)
+        else:
+            params = qs
 
         if self.token:
             try:

--- a/nomad/api/client.py
+++ b/nomad/api/client.py
@@ -10,6 +10,7 @@ class Client(object):
         self.stats = stats(**kwargs)
         self.allocation = allocation(**kwargs)
         self.readat = readat(**kwargs)
+        self.streamfile = streamfile(**kwargs)
 
     def __str__(self):
         return "{0}".format(self.__dict__)
@@ -116,12 +117,48 @@ class readat(Requester):
             returns: (str) text
             raises:
               - nomad.api.exceptions.BaseNomadException
-              - nomad.api.exceptions.URLNotFoundNomadException
+              - nomad.api.exceptions.BadRequestNomadException
         """
         params = {
             "path": path,
             "offset": offset,
             "limit": limit
+        }
+        return self.request(id, params=params, method="get").text
+
+
+class streamfile(Requester):
+
+    """
+    This endpoint streams the contents of a file in an allocation directory.
+
+    https://www.nomadproject.io/api/client.html#stream-file
+    """
+
+    ENDPOINT = "client/fs/stream"
+
+    def __init__(self, **kwargs):
+        super(streamfile, self).__init__(**kwargs)
+
+    def stream(self, id, offset, origin, path="/"):
+        """ Read contents of a file in an allocation directory.
+
+           https://www.nomadproject.io/docs/http/client-fs-cat.html
+
+            arguments:
+              - id: (str) allocation_id required
+              - offset: (int) required
+              - origin: (str) either start|end
+              - path: (str) optional
+            returns: (str) text
+            raises:
+              - nomad.api.exceptions.BaseNomadException
+              - nomad.api.exceptions.BadRequestNomadException
+        """
+        params = {
+            "path": path,
+            "offset": offset,
+            "origin": origin
         }
         return self.request(id, params=params, method="get").text
 

--- a/nomad/api/client.py
+++ b/nomad/api/client.py
@@ -11,6 +11,7 @@ class Client(object):
         self.allocation = allocation(**kwargs)
         self.readat = readat(**kwargs)
         self.streamfile = streamfile(**kwargs)
+        self.streamlogs = streamlogs(**kwargs)
 
     def __str__(self):
         return "{0}".format(self.__dict__)
@@ -141,9 +142,9 @@ class streamfile(Requester):
         super(streamfile, self).__init__(**kwargs)
 
     def stream(self, id, offset, origin, path="/"):
-        """ Read contents of a file in an allocation directory.
+        """ This endpoint streams the contents of a file in an allocation directory.
 
-           https://www.nomadproject.io/docs/http/client-fs-cat.html
+            https://www.nomadproject.io/api/client.html#stream-file
 
             arguments:
               - id: (str) allocation_id required
@@ -159,6 +160,48 @@ class streamfile(Requester):
             "path": path,
             "offset": offset,
             "origin": origin
+        }
+        return self.request(id, params=params, method="get").text
+
+
+class streamlogs(Requester):
+
+    """
+    This endpoint streams a task's stderr/stdout logs.
+
+    https://www.nomadproject.io/api/client.html#stream-logs
+    """
+
+    ENDPOINT = "client/fs/logs"
+
+    def __init__(self, **kwargs):
+        super(streamlogs, self).__init__(**kwargs)
+
+    def stream(self, id, task, type, follow=False, offset=0, origin="start", plain=False):
+        """ This endpoint streams a task's stderr/stdout logs.
+
+            https://www.nomadproject.io/api/client.html#stream-logs
+
+            arguments:
+              - id: (str) allocation_id required
+              - task: (str) name of the task inside the allocation to stream logs from
+              - type: (str) Specifies the stream to stream. Either "stderr|stdout"
+              - follow: (bool) default false
+              - offset: (int) default 0
+              - origin: (str) either start|end, default "start"
+              - plain: (bool) Return just the plain text without framing. default False
+            returns: (str) text
+            raises:
+              - nomad.api.exceptions.BaseNomadException
+              - nomad.api.exceptions.BadRequestNomadException
+        """
+        params = {
+            "task": task,
+            "type": type,
+            "follow": follow,
+            "offset": offset,
+            "origin": origin,
+            "plain": plain
         }
         return self.request(id, params=params, method="get").text
 

--- a/nomad/api/client.py
+++ b/nomad/api/client.py
@@ -9,9 +9,10 @@ class Client(object):
         self.stat = stat(**kwargs)
         self.stats = stats(**kwargs)
         self.allocation = allocation(**kwargs)
-        self.readat = readat(**kwargs)
-        self.streamfile = streamfile(**kwargs)
-        self.streamlogs = streamlogs(**kwargs)
+        self.read_at = read_at(**kwargs)
+        self.stream_file = stream_file(**kwargs)
+        self.stream_logs = stream_logs(**kwargs)
+        self.gc_allocation = gc_allocation(**kwargs)
 
     def __str__(self):
         return "{0}".format(self.__dict__)
@@ -92,7 +93,7 @@ class cat(Requester):
             return self.request(params={"path": path}, method="get").text
 
 
-class readat(Requester):
+class read_at(Requester):
 
     """
     This endpoint reads the contents of a file in an allocation directory at a particular offset and limit.
@@ -103,7 +104,7 @@ class readat(Requester):
     ENDPOINT = "client/fs/readat"
 
     def __init__(self, **kwargs):
-        super(readat, self).__init__(**kwargs)
+        super(read_at, self).__init__(**kwargs)
 
     def read_file_offset(self, id, offset, limit, path="/"):
         """ Read contents of a file in an allocation directory.
@@ -128,7 +129,7 @@ class readat(Requester):
         return self.request(id, params=params, method="get").text
 
 
-class streamfile(Requester):
+class stream_file(Requester):
 
     """
     This endpoint streams the contents of a file in an allocation directory.
@@ -139,7 +140,7 @@ class streamfile(Requester):
     ENDPOINT = "client/fs/stream"
 
     def __init__(self, **kwargs):
-        super(streamfile, self).__init__(**kwargs)
+        super(stream_file, self).__init__(**kwargs)
 
     def stream(self, id, offset, origin, path="/"):
         """ This endpoint streams the contents of a file in an allocation directory.
@@ -164,7 +165,7 @@ class streamfile(Requester):
         return self.request(id, params=params, method="get").text
 
 
-class streamlogs(Requester):
+class stream_logs(Requester):
 
     """
     This endpoint streams a task's stderr/stdout logs.
@@ -175,7 +176,7 @@ class streamlogs(Requester):
     ENDPOINT = "client/fs/logs"
 
     def __init__(self, **kwargs):
-        super(streamlogs, self).__init__(**kwargs)
+        super(stream_logs, self).__init__(**kwargs)
 
     def stream(self, id, task, type, follow=False, offset=0, origin="start", plain=False):
         """ This endpoint streams a task's stderr/stdout logs.
@@ -297,3 +298,30 @@ class allocation(Requester):
               - nomad.api.exceptions.URLNotFoundNomadException
         """
         return self.request(id, "stats", method="get").json()
+
+
+class gc_allocation(Requester):
+
+    """
+    This endpoint forces a garbage collection of a particular, stopped allocation on a node.
+
+    https://www.nomadproject.io/api/client.html#gc-allocation
+    """
+
+    ENDPOINT = "client/allocation"
+
+    def __init__(self, **kwargs):
+        super(gc_allocation, self).__init__(**kwargs)
+
+    def garbage_collect(self, id):
+        """ This endpoint forces a garbage collection of a particular, stopped allocation on a node.
+
+            https://www.nomadproject.io/api/client.html#gc-allocation
+
+            arguments:
+              - id: (str) full allocation_id
+            raises:
+              - nomad.api.exceptions.BaseNomadException
+              - nomad.api.exceptions.URLNotFoundNomadException
+        """
+        self.request(id, "gc", method="get")

--- a/nomad/api/client.py
+++ b/nomad/api/client.py
@@ -1,15 +1,14 @@
+from nomad.api.base import Requester
+
 
 class Client(object):
 
-    ENDPOINT = "client"
-
-    def __init__(self, requester):
-        self._requester = requester
-        self.ls = ls(requester)
-        self.cat = cat(requester)
-        self.stat = stat(requester)
-        self.stats = stats(requester)
-        self.allocation = allocation(requester)
+    def __init__(self, **kwargs):
+        self.ls = ls(**kwargs)
+        self.cat = cat(**kwargs)
+        self.stat = stat(**kwargs)
+        self.stats = stats(**kwargs)
+        self.allocation = allocation(**kwargs)
 
     def __str__(self):
         return "{0}".format(self.__dict__)
@@ -20,21 +19,8 @@ class Client(object):
     def __getattr__(self, item):
         raise AttributeError
 
-    def _get(self, *args, **kwargs):
-        try:
-            url = self._requester._endpointBuilder(
-                Client.ENDPOINT, *args)
 
-            response = self._requester.get(url, params=kwargs)
-
-            return response.json()
-        except ValueError:
-            return response.text
-        except:
-            raise
-
-
-class ls(Client):
+class ls(Requester):
 
     """
     The /fs/ls endpoint is used to list files in an allocation directory.
@@ -44,10 +30,10 @@ class ls(Client):
     https://www.nomadproject.io/docs/http/client-fs-ls.html
     """
 
-    ENDPOINT = "fs/ls"
+    ENDPOINT = "client/fs/ls"
 
-    def __init__(self, requester):
-        self._requester = requester
+    def __init__(self, **kwargs):
+        super(ls, self).__init__(**kwargs)
 
     def list_files(self, id, path="/"):
         """ List files in an allocation directory.
@@ -62,10 +48,10 @@ class ls(Client):
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self._get(ls.ENDPOINT, id, path=path)
+        return self.request(ls.ENDPOINT, id, params=path, method="get").json()
 
 
-class cat(Client):
+class cat(Requester):
 
     """
     The /fs/cat endpoint is used to read the contents of a file in an
@@ -76,10 +62,10 @@ class cat(Client):
     https://www.nomadproject.io/docs/http/client-fs-cat.html
     """
 
-    ENDPOINT = "fs/cat"
+    ENDPOINT = "client/fs/cat"
 
-    def __init__(self, requester):
-        self._requester = requester
+    def __init__(self, **kwargs):
+        super(cat, self).__init__(**kwargs)
 
     def read_file(self, id, path="/"):
         """ Read contents of a file in an allocation directory.
@@ -89,15 +75,15 @@ class cat(Client):
             arguments:
               - id
               - path
-            returns: text
+            returns: (str) text
             raises:
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self._get(cat.ENDPOINT, id, path=path)
+        return self.request(cat.ENDPOINT, id, params=path, method="get").text
 
 
-class stat(Client):
+class stat(Requester):
 
     """
     The /fs/stat endpoint is used to show stat information 
@@ -107,10 +93,10 @@ class stat(Client):
     https://www.nomadproject.io/docs/http/client-fs-stat.html
     """
 
-    ENDPOINT = "fs/stat"
+    ENDPOINT = "client/fs/stat"
 
-    def __init__(self, requester):
-        self._requester = requester
+    def __init__(self, **kwargs):
+        super(stat, self).__init__(**kwargs)
 
     def stat_file(self, id, path="/"):
         """ Stat a file in an allocation directory.
@@ -125,10 +111,10 @@ class stat(Client):
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self._get(stat.ENDPOINT, id, path=path)
+        return self.request(stat.ENDPOINT, id, params=path, method="get").json()
 
 
-class stats(Client):
+class stats(Requester):
 
     """
     The /stats endpoint queries the actual resources consumed on a node.
@@ -138,10 +124,10 @@ class stats(Client):
     https://www.nomadproject.io/api/client.html#read-stats
     """
 
-    ENDPOINT = "stats"
+    ENDPOINT = "client/stats"
 
-    def __init__(self, requester):
-        self._requester = requester
+    def __init__(self, **kwargs):
+        super(stats, self).__init__(**kwargs)
 
     def read_stats(self):
         """ Query the actual resources consumed on a node.
@@ -154,10 +140,10 @@ class stats(Client):
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self._get(stats.ENDPOINT)
+        return self.request(stats.ENDPOINT, method="get").json()
 
 
-class allocation(Client):
+class allocation(Requester):
 
     """
     The allocation/:alloc_id/stats endpoint is used to query the actual
@@ -168,10 +154,10 @@ class allocation(Client):
     https://www.nomadproject.io/api/client.html#read-allocation
     """
 
-    ENDPOINT = "allocation"
+    ENDPOINT = "client/allocation"
 
-    def __init__(self, requester):
-        self._requester = requester
+    def __init__(self, **kwargs):
+        super(allocation, self).__init__(**kwargs)
 
     def read_allocation_stats(self, id):
         """ Query the actual resources consumed by an allocation.
@@ -185,4 +171,4 @@ class allocation(Client):
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self._get(allocation.ENDPOINT, id, "stats")
+        return self.request(allocation.ENDPOINT, id, "stats", method="get").json()

--- a/nomad/api/client.py
+++ b/nomad/api/client.py
@@ -35,7 +35,7 @@ class ls(Requester):
     def __init__(self, **kwargs):
         super(ls, self).__init__(**kwargs)
 
-    def list_files(self, id, path="/"):
+    def list_files(self, id=None, path="/"):
         """ List files in an allocation directory.
 
            https://www.nomadproject.io/docs/http/client-fs-ls.html
@@ -48,7 +48,10 @@ class ls(Requester):
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self.request(id, params={"path": path}, method="get").json()
+        if id:
+            return self.request(id, params={"path": path}, method="get").json()
+        else:
+            return self.request(params={"path": path}, method="get").json()
 
 
 class cat(Requester):
@@ -67,7 +70,7 @@ class cat(Requester):
     def __init__(self, **kwargs):
         super(cat, self).__init__(**kwargs)
 
-    def read_file(self, id, path="/"):
+    def read_file(self, id=None, path="/"):
         """ Read contents of a file in an allocation directory.
 
            https://www.nomadproject.io/docs/http/client-fs-cat.html
@@ -80,7 +83,10 @@ class cat(Requester):
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self.request(id, params={"path": path}, method="get").text
+        if id:
+            return self.request(id, params={"path": path}, method="get").text
+        else:
+            return self.request(params={"path": path}, method="get").text
 
 
 class stat(Requester):
@@ -98,7 +104,7 @@ class stat(Requester):
     def __init__(self, **kwargs):
         super(stat, self).__init__(**kwargs)
 
-    def stat_file(self, id, path="/"):
+    def stat_file(self, id=None, path="/"):
         """ Stat a file in an allocation directory.
 
            https://www.nomadproject.io/docs/http/client-fs-stat.html
@@ -111,7 +117,10 @@ class stat(Requester):
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self.request(id, params={"path": path}, method="get").json()
+        if id:
+            return self.request(id, params={"path": path}, method="get").json()
+        else:
+            return self.request(params={"path": path}, method="get").json()
 
 
 class stats(Requester):

--- a/nomad/api/client.py
+++ b/nomad/api/client.py
@@ -48,7 +48,7 @@ class ls(Requester):
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self.request(ls.ENDPOINT, id, params=path, method="get").json()
+        return self.request(id, params={"path": path}, method="get").json()
 
 
 class cat(Requester):
@@ -80,7 +80,7 @@ class cat(Requester):
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self.request(cat.ENDPOINT, id, params=path, method="get").text
+        return self.request(id, params={"path": path}, method="get").text
 
 
 class stat(Requester):
@@ -111,7 +111,7 @@ class stat(Requester):
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self.request(stat.ENDPOINT, id, params=path, method="get").json()
+        return self.request(id, params={"path": path}, method="get").json()
 
 
 class stats(Requester):
@@ -129,7 +129,7 @@ class stats(Requester):
     def __init__(self, **kwargs):
         super(stats, self).__init__(**kwargs)
 
-    def read_stats(self):
+    def read_stats(self, node_id=None):
         """ Query the actual resources consumed on a node.
 
             https://www.nomadproject.io/api/client.html#read-stats
@@ -140,7 +140,7 @@ class stats(Requester):
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self.request(stats.ENDPOINT, method="get").json()
+        return self.request(params={"node_id": node_id}, method="get").json()
 
 
 class allocation(Requester):
@@ -165,10 +165,9 @@ class allocation(Requester):
             https://www.nomadproject.io/api/client.html#read-allocation
 
             arguments:
-              - id
             returns: dict
             raises:
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self.request(allocation.ENDPOINT, id, "stats", method="get").json()
+        return self.request(id, "stats", method="get").json()

--- a/nomad/api/deployments.py
+++ b/nomad/api/deployments.py
@@ -1,7 +1,9 @@
 import nomad.api.exceptions
 
+from nomad.api.base import Requester
 
-class Deployments(object):
+
+class Deployments(Requester):
 
     """
     The /deployment endpoints are used to query for and interact with deployments.
@@ -10,8 +12,8 @@ class Deployments(object):
     """
     ENDPOINT = "deployments"
 
-    def __init__(self, requester):
-        self._requester = requester
+    def __init__(self, **kwargs):
+        super(Deployments, self).__init__(**kwargs)
 
     def __str__(self):
         return "{0}".format(self.__dict__)
@@ -23,16 +25,16 @@ class Deployments(object):
         raise AttributeError
 
     def __len__(self):
-        response = self._get()
+        response = self.get_deployments()
         return len(response)
 
     def __iter__(self):
-        response = self._get()
+        response = self.get_deployments()
         return iter(response)
 
     def __contains__(self, item):
         try:
-            deployments = self._get()
+            deployments = self.get_deployments()
 
             for d in deployments:
                 if d["ID"] == item:
@@ -44,7 +46,7 @@ class Deployments(object):
 
     def __getitem__(self, item):
         try:
-            deployments = self._get()
+            deployments = self.get_deployments()
 
             for d in deployments:
                 if d["ID"] == item:
@@ -53,12 +55,6 @@ class Deployments(object):
                 raise KeyError
         except nomad.api.exceptions.URLNotFoundNomadException:
             raise KeyError
-
-    def _get(self, *args, **kwargs):
-        url = self._requester._endpointBuilder(Deployments.ENDPOINT, *args)
-        response = self._requester.get(url, params=kwargs.get("params", None))
-
-        return response.json()
 
     def get_deployments(self, prefix=""):
         """ This endpoint lists all deployments.
@@ -75,4 +71,4 @@ class Deployments(object):
               - nomad.api.exceptions.URLNotFoundNomadException
         """
         params = {"prefix": prefix}
-        return self._get(params=params)
+        return self.request(params=params, method="get").json()

--- a/nomad/api/evaluation.py
+++ b/nomad/api/evaluation.py
@@ -1,7 +1,9 @@
 import nomad.api.exceptions
 
+from nomad.api.base import Requester
 
-class Evaluation(object):
+
+class Evaluation(Requester):
 
     """
     The evaluation endpoint is used to query a specific evaluations.
@@ -12,8 +14,8 @@ class Evaluation(object):
     """
     ENDPOINT = "evaluation"
 
-    def __init__(self, requester):
-        self._requester = requester
+    def __init__(self, **kwargs):
+        super(Evaluation, self).__init__(**kwargs)
 
     def __str__(self):
         return "{0}".format(self.__dict__)
@@ -28,7 +30,7 @@ class Evaluation(object):
     def __contains__(self, item):
 
         try:
-            e = self._get(item)
+            e = self.get_evaluation(item)
             return True
         except nomad.api.exceptions.URLNotFoundNomadException:
             return False
@@ -36,18 +38,12 @@ class Evaluation(object):
     def __getitem__(self, item):
 
         try:
-            e = self._get(item)
+            e = self.get_evaluation(item)
 
             if e["ID"] == item:
                 return e
         except nomad.api.exceptions.URLNotFoundNomadException:
             raise KeyError
-
-    def _get(self, *args):
-        url = self._requester._endpointBuilder(Evaluation.ENDPOINT, *args)
-        evaluation = self._requester.get(url)
-
-        return evaluation.json()
 
     def get_evaluation(self, id):
         """ Query a specific evaluation.
@@ -61,7 +57,7 @@ class Evaluation(object):
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self._get(id)
+        return self.request(id, method="get").json()
 
     def get_allocations(self, id):
         """ Query the allocations created or modified by an evaluation.
@@ -75,4 +71,4 @@ class Evaluation(object):
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self._get(id, "allocations")
+        return self.request(id, "allocations", method="get").json()

--- a/nomad/api/evaluations.py
+++ b/nomad/api/evaluations.py
@@ -1,7 +1,8 @@
 import nomad.api.exceptions
 
+from nomad.api.base import Requester
 
-class Evaluations(object):
+class Evaluations(Requester):
 
     """
     The evaluations endpoint is used to query the status of evaluations.
@@ -12,8 +13,8 @@ class Evaluations(object):
     """
     ENDPOINT = "evaluations"
 
-    def __init__(self, requester):
-        self._requester = requester
+    def __init__(self, **kwargs):
+        super(Evaluations, self).__init__(**kwargs)
 
     def __str__(self):
         return "{0}".format(self.__dict__)
@@ -26,7 +27,7 @@ class Evaluations(object):
 
     def __contains__(self, item):
         try:
-            evaluations = self._get()
+            evaluations = self.get_evaluations()
 
             for e in evaluations:
                 if e["ID"] == item:
@@ -37,12 +38,12 @@ class Evaluations(object):
             return False
 
     def __len__(self):
-        evaluations = self._get()
+        evaluations = self.get_evaluations()
         return len(evaluations)
 
     def __getitem__(self, item):
         try:
-            evaluations = self._get()
+            evaluations = self.get_evaluations()
 
             for e in evaluations:
                 if e["ID"] == item:
@@ -53,14 +54,8 @@ class Evaluations(object):
             raise KeyError
 
     def __iter__(self):
-        evaluations = self._get()
+        evaluations = self.get_evaluations()
         return iter(evaluations)
-
-    def _get(self, *args):
-        url = self._requester._endpointBuilder(Evaluations.ENDPOINT, *args)
-        evaluations = self._requester.get(url)
-
-        return evaluations.json()
 
     def get_evaluations(self):
         """ Lists all the evaluations.
@@ -72,4 +67,4 @@ class Evaluations(object):
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self._get()
+        return self.request(method="get").json()

--- a/nomad/api/exceptions.py
+++ b/nomad/api/exceptions.py
@@ -4,14 +4,20 @@ class BaseNomadException(Exception):
         self.nomad_resp = nomad_resp
 
 
-class URLNotFoundNomadException(Exception):
+class URLNotFoundNomadException(BaseNomadException):
     """The requeted URL given does not exist"""
     def __init__(self, nomad_resp):
         self.nomad_resp = nomad_resp
         
 
-class URLNotAuthorizedNomadException(Exception):
+class URLNotAuthorizedNomadException(BaseNomadException):
     """The requested URL is not authorized. ACL"""
+    def __init__(self, nomad_resp):
+        self.nomad_resp = nomad_resp
+
+
+class BadRequestNomadException(BaseNomadException):
+    """Validation failure and if a parameter is modified in the request, it could potentially succeed."""
     def __init__(self, nomad_resp):
         self.nomad_resp = nomad_resp
 

--- a/nomad/api/job.py
+++ b/nomad/api/job.py
@@ -1,7 +1,9 @@
 import nomad.api.exceptions
 
+from nomad.api.base import Requester
 
-class Job(object):
+
+class Job(Requester):
 
     """
     The job endpoint is used for CRUD on a single job.
@@ -11,8 +13,8 @@ class Job(object):
     """
     ENDPOINT = "job"
 
-    def __init__(self, requester):
-        self._requester = requester
+    def __init__(self, **kwargs):
+        super(Job, self).__init__(**kwargs)
 
     def __str__(self):
         return "{0}".format(self.__dict__)
@@ -27,7 +29,7 @@ class Job(object):
     def __contains__(self, item):
 
         try:
-            j = self._get(item)
+            j = self.get_job(item)
             return True
         except nomad.api.exceptions.URLNotFoundNomadException:
             return False
@@ -35,7 +37,7 @@ class Job(object):
     def __getitem__(self, item):
 
         try:
-            j = self._get(item)
+            j = self.get_job(item)
 
             if j["ID"] == item:
                 return j
@@ -45,12 +47,6 @@ class Job(object):
                 raise KeyError
         except nomad.api.exceptions.URLNotFoundNomadException:
             raise KeyError
-
-    def _get(self, *args):
-        url = self._requester._endpointBuilder(Job.ENDPOINT, *args)
-        job = self._requester.get(url)
-
-        return job.json()
 
     def get_job(self, id):
         """ Query a single job for its specification and status.
@@ -64,7 +60,7 @@ class Job(object):
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self._get(id)
+        return self.request(id, method="get").json()
 
     def get_versions(self, id):
         """ This endpoint reads information about all versions of a job.
@@ -78,7 +74,7 @@ class Job(object):
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self._get(id, "versions")
+        return self.request(id, "versions", method="get").json()
 
     def get_allocations(self, id):
         """ Query the allocations belonging to a single job.
@@ -92,7 +88,7 @@ class Job(object):
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self._get(id, "allocations")
+        return self.request(id, "allocations", method="get").json()
 
     def get_evaluations(self, id):
         """ Query the evaluations belonging to a single job.
@@ -106,7 +102,7 @@ class Job(object):
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self._get(id, "evaluations")
+        return self.request(id, "evaluations", method="get").json()
 
     def get_deployments(self, id):
         """ This endpoint lists a single job's deployments
@@ -120,7 +116,7 @@ class Job(object):
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self._get(id, "deployments")
+        return self.request(id, "deployments", method="get").json()
 
     def get_deployment(self, id):
         """ This endpoint returns a single job's most recent deployment.
@@ -134,7 +130,7 @@ class Job(object):
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self._get(id, "deployment")
+        return self.request(id, "deployment", method="get").json()
 
     def get_summary(self, id):
         """ Query the summary of a job.
@@ -148,17 +144,7 @@ class Job(object):
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self._get(id, "summary")
-
-    def _post(self, *args, **kwargs):
-        url = self._requester._endpointBuilder(Job.ENDPOINT, *args)
-
-        if kwargs:
-            response = self._requester.post(url, json=kwargs.get("json_dict", None), params=kwargs.get("params", None))
-        else:
-            response = self._requester.post(url)
-
-        return response.json()
+        return self.request(id, "summary", method="get").json()
 
     def register_job(self, id, job):
         """ Registers a new job or updates an existing job
@@ -172,7 +158,7 @@ class Job(object):
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self._post(id, json_dict=job)
+        return self.request(id, json=job, method="post").json()
 
     def evaluate_job(self, id):
         """ Creates a new evaluation for the given job.
@@ -187,7 +173,7 @@ class Job(object):
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self._post(id, "evaluate")
+        return self.request(id, "evaluate", method="post").json()
 
     def plan_job(self, id, job, diff=False, policy_override=False):
         """ Invoke a dry-run of the scheduler for the job.
@@ -208,7 +194,7 @@ class Job(object):
         json_dict.update(job)
         json_dict.setdefault('Diff', diff)
         json_dict.setdefault('PolicyOverride', policy_override)
-        return self._post(id, "plan", json_dict=json_dict)
+        return self.request(id, "plan", json=json_dict, method="post").json()
 
     def periodic_job(self, id):
         """ Forces a new instance of the periodic job. A new instance will be
@@ -225,7 +211,7 @@ class Job(object):
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self._post(id, "periodic", "force")
+        return self.request(id, "periodic", "force", method="post").json()
     
     def dispatch_job(self, id, payload=None, meta=None):
         """ Dispatches a new instance of a parameterized job.
@@ -242,7 +228,7 @@ class Job(object):
               - nomad.api.exceptions.URLNotFoundNomadException
         """
         dispatch_json = {"Meta": meta, "Payload": payload}
-        return self._post(id, "dispatch", json_dict=dispatch_json)
+        return self.request(id, "dispatch", json=dispatch_json, method="post").json()
 
     def revert_job(self, id, version, enforce_prior_version=None):
         """ This endpoint reverts the job to an older version.
@@ -264,7 +250,7 @@ class Job(object):
         revert_json = {"JobID": id,
                        "JobVersion": version,
                        "EnforcePriorVersion": enforce_prior_version}
-        return self._post(id, "revert", json_dict=revert_json)
+        return self.request(id, "revert", json=revert_json, method="post").json()
 
     def stable_job(self, id, version, stable):
         """ This endpoint sets the job's stability.
@@ -283,13 +269,7 @@ class Job(object):
         revert_json = {"JobID": id,
                        "JobVersion": version,
                        "Stable": stable}
-        return self._post(id, "stable", json_dict=revert_json)
-
-    def _delete(self, *args):
-        url = self._requester._endpointBuilder(Job.ENDPOINT, *args)
-        job = self._requester.delete(url)
-
-        return job.json()
+        return self.request(id, "stable", json=revert_json, method="post").json()
 
     def deregister_job(self, id):
         """ Deregisters a job, and stops all allocations part of it.
@@ -303,4 +283,4 @@ class Job(object):
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self._delete(id)
+        return self.request(id, method="delete").json()

--- a/nomad/api/metrics.py
+++ b/nomad/api/metrics.py
@@ -1,7 +1,7 @@
-import nomad.api.exceptions
+from nomad.api.base import Requester
 
 
-class Metrics(object):
+class Metrics(Requester):
 
     """
     The /metrics endpoint returns metrics for the current Nomad process.
@@ -14,8 +14,8 @@ class Metrics(object):
     """
     ENDPOINT = "metrics"
 
-    def __init__(self, requester):
-        self._requester = requester
+    def __init__(self, **kwargs):
+        super(Metrics, self).__init__(**kwargs)
 
     def __str__(self):
         return "{0}".format(self.__dict__)
@@ -25,12 +25,6 @@ class Metrics(object):
 
     def __getattr__(self, item):
         raise AttributeError
-
-    def _get(self, *args):
-        url = self._requester._endpointBuilder(Metrics.ENDPOINT, *args)
-        metrics = self._requester.get(url)
-
-        return metrics.json()
 
     def get_metrics(self):
         """ Get the metrics
@@ -42,4 +36,4 @@ class Metrics(object):
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self._get()
+        return self.request(method="get").json()

--- a/nomad/api/namespace.py
+++ b/nomad/api/namespace.py
@@ -1,7 +1,9 @@
 import nomad.api.exceptions
 
+from nomad.api.base import Requester
 
-class Namespace(object):
+
+class Namespace(Requester):
 
     """
     The job endpoint is used for CRUD on a single namespace.
@@ -11,8 +13,8 @@ class Namespace(object):
     """
     ENDPOINT = "namespace"
 
-    def __init__(self, requester):
-        self._requester = requester
+    def __init__(self, **kwargs):
+        super(Namespace, self).__init__(**kwargs)
 
     def __str__(self):
         return "{0}".format(self.__dict__)
@@ -27,7 +29,7 @@ class Namespace(object):
     def __contains__(self, item):
 
         try:
-            j = self._get(item)
+            j = self.get_namespace(item)
             return True
         except nomad.api.exceptions.URLNotFoundNomadException:
             return False
@@ -35,7 +37,7 @@ class Namespace(object):
     def __getitem__(self, item):
 
         try:
-            j = self._get(item)
+            j = self.get_namespace(item)
 
             if j["ID"] == item:
                 return j
@@ -45,27 +47,6 @@ class Namespace(object):
                 raise KeyError
         except nomad.api.exceptions.URLNotFoundNomadException:
             raise KeyError
-
-    def _get(self, *args):
-        url = self._requester._endpointBuilder(Namespace.ENDPOINT, *args)
-        namespace = self._requester.get(url)
-
-        return namespace.json()
-
-    def _post(self, *args, **kwargs):
-        url = self._requester._endpointBuilder(Namespace.ENDPOINT, *args)
-        if kwargs:
-            response = self._requester.post(url, json=kwargs.get("json_dict", None), params=kwargs.get("params", None))
-        else:
-            response = self._requester.post(url)
-
-        return response
-
-    def _delete(self, *args):
-        url = self._requester._endpointBuilder(Namespace.ENDPOINT, *args)
-        namespace = self._requester.delete(url)
-
-        return namespace
 
     def get_namespace(self, id):
         """ Query a single namespace.
@@ -79,8 +60,7 @@ class Namespace(object):
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self._get(id)
-
+        return self.request(id, method="get").json()
 
     def create_namespace(self, namespace):
         """ create namespace
@@ -90,12 +70,12 @@ class Namespace(object):
             arguments:
               - id
               - namespace (dict)
-            returns: None
+            returns: requests.Response
             raises:
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self._post(json_dict=namespace)
+        return self.request(json=namespace, method="post")
 
     def update_namespace(self, id, namespace):
         """ Update namespace
@@ -105,12 +85,12 @@ class Namespace(object):
             arguments:
               - id
               - namespace (dict)
-            returns: None
+            returns: requests.Response
             raises:
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self._post(id, json_dict=namespace)
+        return self.request(id, json=namespace, method="post")
 
     def delete_namespace(self, id):
         """ delete namespace.
@@ -119,9 +99,9 @@ class Namespace(object):
 
             arguments:
               - id
-            returns: dict
+            returns: requests.Response
             raises:
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self._delete(id)
+        return self.request(id, method="delete")

--- a/nomad/api/namespaces.py
+++ b/nomad/api/namespaces.py
@@ -1,7 +1,9 @@
 import nomad.api.exceptions
 
+from nomad.api.base import Requester
 
-class Namespaces(object):
+
+class Namespaces(Requester):
 
     """
     The namespaces from enterprise solution
@@ -10,8 +12,8 @@ class Namespaces(object):
     """
     ENDPOINT = "namespaces"
 
-    def __init__(self, requester):
-        self._requester = requester
+    def __init__(self, **kwargs):
+        super(Namespaces, self).__init__(**kwargs)
 
     def __str__(self):
         return "{0}".format(self.__dict__)
@@ -25,10 +27,10 @@ class Namespaces(object):
 
     def __contains__(self, item):
         try:
-            namespaces = self._get()
+            namespaces = self.get_namespaces()
 
-            for j in namespaces:
-                if j["Name"] == item:
+            for n in namespaces:
+                if n["Name"] == item:
                     return True
             else:
                 return False
@@ -36,30 +38,24 @@ class Namespaces(object):
             return False
 
     def __len__(self):
-        namespaces = self._get()
+        namespaces = self.get_namespaces()
         return len(namespaces)
 
     def __getitem__(self, item):
         try:
-            namespaces = self._get()
+            namespaces = self.get_namespaces()
 
-            for j in namespaces:
-                if j["Name"] == item:
-                    return j
+            for n in namespaces:
+                if n["Name"] == item:
+                    return n
             else:
                 raise KeyError
         except nomad.api.exceptions.URLNotFoundNomadException:
             raise KeyError
 
     def __iter__(self):
-        namespaces = self._get()
+        namespaces = self.get_namespaces()
         return iter(namespaces)
-
-    def _get(self, *args):
-        url = self._requester._endpointBuilder(Namespaces.ENDPOINT, *args)
-        namespaces = self._requester.get(url)
-
-        return namespaces.json()
 
     def get_namespaces(self):
         """ Lists all the namespaces registered with Nomad.
@@ -71,4 +67,4 @@ class Namespaces(object):
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self._get()
+        return self.request(method="get").json()

--- a/nomad/api/node.py
+++ b/nomad/api/node.py
@@ -1,7 +1,9 @@
 import nomad.api.exceptions
 
+from nomad.api.base import Requester
 
-class Node(object):
+
+class Node(Requester):
 
     """
     The node endpoint is used to query the a specific client node.
@@ -11,8 +13,8 @@ class Node(object):
     """
     ENDPOINT = "node"
 
-    def __init__(self, requester):
-        self._requester = requester
+    def __init__(self, **kwargs):
+        super(Node, self).__init__(**kwargs)
 
     def __str__(self):
         return "{0}".format(self.__dict__)
@@ -27,7 +29,7 @@ class Node(object):
     def __contains__(self, item):
 
         try:
-            n = self._get(item)
+            n = self.get_node(item)
             return True
         except nomad.api.exceptions.URLNotFoundNomadException:
             return False
@@ -35,7 +37,7 @@ class Node(object):
     def __getitem__(self, item):
 
         try:
-            n = self._get(item)
+            n = self.get_node(item)
 
             if n["ID"] == item:
                 return n
@@ -45,12 +47,6 @@ class Node(object):
                 raise KeyError
         except nomad.api.exceptions.URLNotFoundNomadException:
             raise KeyError
-
-    def _get(self, *args):
-        url = self._requester._endpointBuilder(Node.ENDPOINT, *args)
-        node = self._requester.get(url)
-
-        return node.json()
 
     def get_node(self, id):
         """ Query the status of a client node registered with Nomad.
@@ -62,7 +58,7 @@ class Node(object):
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self._get(id)
+        return self.request(id, method="get").json()
 
     def get_allocations(self, id):
         """ Query the allocations belonging to a single node.
@@ -74,17 +70,7 @@ class Node(object):
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self._get(id, "allocations")
-
-    def _post(self, *args, **kwargs):
-        url = self._requester._endpointBuilder(Node.ENDPOINT, *args)
-
-        if kwargs:
-            response = self._requester.post(url, params=kwargs.get("enable", None), json=kwargs.get("payload", {}))
-        else:
-            response = self._requester.post(url)
-
-        return response.json()
+        return self.request(id, "allocations", method="get").json()
 
     def evaluate_node(self, id):
         """ Creates a new evaluation for the given node.
@@ -98,7 +84,7 @@ class Node(object):
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self._post(id, "evaluate")
+        return self.request(id, "evaluate", method="post").json()
 
     def drain_node(self, id, enable=False):
         """ Toggle the drain mode of the node.
@@ -116,7 +102,7 @@ class Node(object):
               - nomad.api.exceptions.URLNotFoundNomadException
         """
 
-        return self._post(id, "drain", enable={"enable": enable})
+        return self.request(id, "drain", params={"enable": enable}, method="post").json()
 
     def drain_node_with_spec(self, id, drain_spec, mark_eligible=None):
         """ This endpoint toggles the drain mode of the node. When draining is enabled,
@@ -161,7 +147,7 @@ class Node(object):
                 "DrainSpec": None,
             }
 
-        return self._post(id, "drain", payload=payload)
+        return self.request(id, "drain", json=payload, method="post").json()
 
     def eligible_node(self, id, eligible=None, ineligible=None):
         """ Toggle the eligibility of the node.
@@ -193,7 +179,7 @@ class Node(object):
         elif ineligible is not None and not ineligible:
             payload = {"Eligibility": "eligible", "NodeID": id}
 
-        return self._post(id, "eligibility", payload=payload)
+        return self.request(id, "eligibility", json=payload, method="post").json()
 
     def purge_node(self, id):
         """ This endpoint purges a node from the system. Nodes can still join the cluster if they are alive.
@@ -205,5 +191,5 @@ class Node(object):
           - nomad.api.exceptions.URLNotFoundNomadException
         """
 
-        return self._post(id, "purge")
+        return self.request(id, "purge", method="post").json()
 

--- a/nomad/api/nodes.py
+++ b/nomad/api/nodes.py
@@ -1,7 +1,9 @@
 import nomad.api.exceptions
 
+from nomad.api.base import Requester
 
-class Nodes(object):
+
+class Nodes(Requester):
 
     """
     The nodes endpoint is used to query the status of client nodes.
@@ -11,8 +13,8 @@ class Nodes(object):
     """
     ENDPOINT = "nodes"
 
-    def __init__(self, requester):
-        self._requester = requester
+    def __init__(self, **kwargs):
+        super(Nodes, self).__init__(**kwargs)
 
     def __str__(self):
         return "{0}".format(self.__dict__)
@@ -25,7 +27,7 @@ class Nodes(object):
 
     def __contains__(self, item):
         try:
-            nodes = self._get()
+            nodes = self.get_nodes()
 
             for n in nodes:
                 if n["ID"] == item:
@@ -38,12 +40,12 @@ class Nodes(object):
             return False
 
     def __len__(self):
-        nodes = self._get()
+        nodes = self.get_nodes()
         return len(nodes)
 
     def __getitem__(self, item):
         try:
-            nodes = self._get()
+            nodes = self.get_nodes()
 
             for n in nodes:
                 if n["ID"] == item:
@@ -56,14 +58,8 @@ class Nodes(object):
             raise KeyError
 
     def __iter__(self):
-        nodes = self._get()
+        nodes = self.get_nodes()
         return iter(nodes)
-
-    def _get(self, *args):
-        url = self._requester._endpointBuilder(Nodes.ENDPOINT, *args)
-        nodes = self._requester.get(url)
-
-        return nodes.json()
 
     def get_nodes(self):
         """ Lists all the client nodes registered with Nomad.
@@ -75,4 +71,4 @@ class Nodes(object):
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self._get()
+        return self.request(method="get").json()

--- a/nomad/api/operator.py
+++ b/nomad/api/operator.py
@@ -58,6 +58,5 @@ class Operator(Requester):
               - nomad.api.exceptions.URLNotFoundNomadException
         """
 
-        params = {"address": peer_address,
-                  "stale": stale}
+        params = {"address": peer_address, "stale": stale}
         return self.request("raft", "peer", params=params, method="delete").ok

--- a/nomad/api/operator.py
+++ b/nomad/api/operator.py
@@ -1,5 +1,7 @@
+from nomad.api.base import Requester
 
-class Operator(object):
+
+class Operator(Requester):
 
     """
     The Operator endpoint provides cluster-level tools for
@@ -10,8 +12,8 @@ class Operator(object):
 
     ENDPOINT = "operator"
 
-    def __init__(self, requester):
-        self._requester = requester
+    def __init__(self, **kwargs):
+        super(Operator, self).__init__(**kwargs)
 
     def __str__(self):
         return "{0}".format(self.__dict__)
@@ -21,20 +23,6 @@ class Operator(object):
 
     def __getattr__(self, item):
         raise AttributeError
-
-    def _get(self, *args, **kwargs):
-        url = self._requester._endpointBuilder(Operator.ENDPOINT, *args)
-        response = self._requester.get(url,
-                                       params=kwargs.get("params",None))
-
-        return response.json()
-
-    def _delete(self, *args, **kwargs):
-        url = self._requester._endpointBuilder(Operator.ENDPOINT, *args)
-        response = self._requester.delete(url,
-                                          params=kwargs.get("params", None))
-
-        return response.ok
 
     def get_configuration(self, stale=False):
         """ Query the status of a client node registered with Nomad.
@@ -51,7 +39,7 @@ class Operator(object):
         """
 
         params = {"stale": stale}
-        return self._get("raft", "configuration", params=params)
+        return self.request("raft", "configuration", params=params, method="get").json()
 
     def delete_peer(self, peer_address, stale=False):
         """ Remove the Nomad server with given address from the Raft configuration.
@@ -72,4 +60,4 @@ class Operator(object):
 
         params = {"address": peer_address,
                   "stale": stale}
-        return self._delete("raft", "peer", params=params)
+        return self.request("raft", "peer", params=params, method="delete").ok

--- a/nomad/api/operator.py
+++ b/nomad/api/operator.py
@@ -52,7 +52,7 @@ class Operator(Requester):
             optional arguments:
               - stale, (defaults to False), Specifies if the cluster should respond without an active leader.
                                             This is specified as a querystring parameter.
-            returns: Ok status
+            returns: Boolean
             raises:
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException

--- a/nomad/api/regions.py
+++ b/nomad/api/regions.py
@@ -1,15 +1,17 @@
 import nomad.api.exceptions
 
+from nomad.api.base import Requester
 
-class Regions(object):
+
+class Regions(Requester):
 
     """
     https://www.nomadproject.io/docs/http/regions.html
     """
     ENDPOINT = "regions"
 
-    def __init__(self, requester):
-        self._requester = requester
+    def __init__(self, **kwargs):
+        super(Regions, self).__init__(**kwargs)
 
     def __str__(self):
         return "{0}".format(self.__dict__)
@@ -22,7 +24,7 @@ class Regions(object):
 
     def __contains__(self, item):
         try:
-            regions = self._get()
+            regions = self.get_regions()
 
             for r in regions:
                 if r == item:
@@ -33,12 +35,12 @@ class Regions(object):
             return False
 
     def __len__(self):
-        regions = self._get()
+        regions = self.get_regions()
         return len(regions)
 
     def __getitem__(self, item):
         try:
-            regions = self._get()
+            regions = self.get_regions()
 
             for r in regions:
                 if r == item:
@@ -49,14 +51,8 @@ class Regions(object):
             raise KeyError
 
     def __iter__(self):
-        regions = self._get()
+        regions = self.get_regions()
         return iter(regions)
-
-    def _get(self, *args):
-        url = self._requester._endpointBuilder(Regions.ENDPOINT, *args)
-        nodes = self._requester.get(url)
-
-        return nodes.json()
 
     def get_regions(self):
         """ Returns the known region names.
@@ -68,4 +64,4 @@ class Regions(object):
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self._get()
+        return self.request(method="get").json()

--- a/nomad/api/sentinel.py
+++ b/nomad/api/sentinel.py
@@ -87,6 +87,7 @@ class Sentinel(Requester):
 
             arguments:
                 - id
+            returns: Boolean
 
             raises:
               - nomad.api.exceptions.BaseNomadException

--- a/nomad/api/sentinel.py
+++ b/nomad/api/sentinel.py
@@ -1,7 +1,7 @@
-import nomad.api.exceptions
+from nomad.api.base import Requester
 
 
-class Sentinel(object):
+class Sentinel(Requester):
 
     """
     The endpoint manage sentinel policies (Enterprise Only)
@@ -11,8 +11,8 @@ class Sentinel(object):
 
     ENDPOINT = "sentinel"
 
-    def __init__(self, requester):
-        self._requester = requester
+    def __init__(self, **kwargs):
+        super(Sentinel, self).__init__(**kwargs)
 
     def __str__(self):
         return "{0}".format(self.__dict__)
@@ -22,33 +22,6 @@ class Sentinel(object):
 
     def __getattr__(self, item):
         raise AttributeError
-
-    def _get(self, *args, **kwargs):
-        url = self._requester._endpointBuilder(Sentinel.ENDPOINT, *args)
-        response = self._requester.get(url,
-                                       params=kwargs.get("params", None))
-
-        return response.json()
-
-    def _post(self, *args, **kwargs):
-        url = self._requester._endpointBuilder(Sentinel.ENDPOINT, *args)
-
-        if kwargs:
-            response = self._requester.post(url, json=kwargs.get("json_dict", None), params=kwargs.get("params", None))
-        else:
-            response = self._requester.post(url)
-
-        return response.json()
-
-    def _post_no_json(self, *args, **kwargs):
-        url = self._requester._endpointBuilder(Sentinel.ENDPOINT, *args)
-            
-        if kwargs:
-            response = self._requester.post(url, json=kwargs.get("json_dict", None), params=kwargs.get("params", None))
-        else:
-            response = self._requester.post(url)
-
-        return response
 
     def get_policies(self):
         """ Get a list of policies.
@@ -61,7 +34,7 @@ class Sentinel(object):
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self._get("policies")
+        return self.request("policies", method="get").json()
 
     def create_policy(self, id, policy):
         """ Create policy.
@@ -70,14 +43,13 @@ class Sentinel(object):
 
             arguments:
                 - policy
-            returns: dict
+            returns: requests.Response
 
             raises:
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self._post_no_json("policy", id, json_dict=policy)
-
+        return self.request("policy", id, json=policy, method="post")
 
     def get_policy(self, id):
         """ Get a spacific policy.
@@ -90,7 +62,7 @@ class Sentinel(object):
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self._get("policy", id)
+        return self.request("policy", id, method="get").json()
 
     def update_policy(self, id, policy):
         """ Create policy.
@@ -100,13 +72,13 @@ class Sentinel(object):
             arguments:
                 - name
                 - policy
-            returns: dict
+            returns: requests.Response
 
             raises:
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self._post_no_json("policy", id, json_dict=policy)
+        return self.request("policy", id, json=policy, method="post")
 
     def delete_policy(self, id):
         """ Delete specific policy.
@@ -120,11 +92,4 @@ class Sentinel(object):
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self._delete("policy", id)
-
-    def _delete(self, *args, **kwargs):
-        url = self._requester._endpointBuilder(Sentinel.ENDPOINT, *args)
-        response = self._requester.delete(url,
-                                          params=kwargs.get("params", None))
-
-        return response.ok
+        return self.request("policy", id, method="delete").ok

--- a/nomad/api/system.py
+++ b/nomad/api/system.py
@@ -30,7 +30,7 @@ class System(Requester):
 
             https://www.nomadproject.io/docs/http/system.html
 
-            returns: None
+            returns: Boolean
             raises:
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
@@ -42,7 +42,7 @@ class System(Requester):
 
             https://www.nomadproject.io/docs/http/system.html
 
-            returns: None
+            returns: Boolean
             raises:
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException

--- a/nomad/api/system.py
+++ b/nomad/api/system.py
@@ -1,5 +1,7 @@
+from nomad.api.base import Requester
 
-class System(object):
+
+class System(Requester):
 
     """
     The system endpoint is used to for system maintenance
@@ -11,8 +13,8 @@ class System(object):
 
     ENDPOINT = "system"
 
-    def __init__(self, requester):
-        self._requester = requester
+    def __init__(self, **kwargs):
+        super(System, self).__init__(**kwargs)
 
     def __str__(self):
         return "{0}".format(self.__dict__)
@@ -22,12 +24,6 @@ class System(object):
 
     def __getattr__(self, item):
         raise AttributeError
-
-    def _put(self, *args):
-        url = self._requester._endpointBuilder(System.ENDPOINT, *args)
-        response = self._requester.put(url)
-
-        return response.ok
 
     def initiate_garbage_collection(self):
         """ Initiate garbage collection of jobs, evals, allocations and nodes.
@@ -39,7 +35,7 @@ class System(object):
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self._put("gc")
+        return self.request("gc", method="put").ok
 
     def reconcile_summaries(self):
         """ This endpoint reconciles the summaries of all registered jobs.
@@ -51,4 +47,4 @@ class System(object):
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self._put("reconcile", "summaries")
+        return self.request("reconcile", "summaries", method="put").ok

--- a/nomad/api/validate.py
+++ b/nomad/api/validate.py
@@ -39,4 +39,4 @@ class Validate(Requester):
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self.request("job", json=nomad_job_dict, method="post").ok
+        return self.request("job", json=nomad_job_dict, method="post")

--- a/nomad/api/validate.py
+++ b/nomad/api/validate.py
@@ -1,5 +1,7 @@
+from nomad.api.base import Requester
 
-class Validate(object):
+
+class Validate(Requester):
 
     """
     The system endpoint is used to for system maintenance
@@ -11,8 +13,8 @@ class Validate(object):
 
     ENDPOINT = "validate"
 
-    def __init__(self, requester):
-        self._requester = requester
+    def __init__(self, **kwargs):
+        super(Validate, self).__init__(**kwargs)
 
     def __str__(self):
         return "{0}".format(self.__dict__)
@@ -22,12 +24,6 @@ class Validate(object):
 
     def __getattr__(self, item):
         raise AttributeError
-
-    def _post(self, *args, **kwargs):
-        url = self._requester._endpointBuilder(Validate.ENDPOINT, *args)
-        response = self._requester.post(url, json=kwargs.get("nomad_job_dict", {}))
-
-        return response.ok
 
     def validate_job(self, nomad_job_dict):
         """ This endpoint validates a Nomad job file. The local Nomad agent forwards the request to a server.
@@ -43,4 +39,4 @@ class Validate(object):
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self._post("job", nomad_job_dict=nomad_job_dict)
+        return self.request("job", json=nomad_job_dict, method="post").ok

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,4 @@ requests==2.10.0
 mkdocs==0.15.3
 mock==1.2.0
 responses==0.9.0
+flaky==3.4.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,4 +4,4 @@ pytest-cov==2.2.1
 requests==2.10.0
 mkdocs==0.15.3
 mock==1.2.0
-requests-mock==1.4.0
+responses==0.9.0

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='python-nomad',
-    version='0.9.0',
+    version='1.0.0',
     install_requires=['requests'],
     packages=['nomad', 'nomad.api'],
     url='http://github.com/jrxfive/python-nomad',

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -14,10 +14,12 @@ def test_create_bootstrap(nomad_setup):
     assert "SecretID" in bootstrap
     common.NOMAD_TOKEN = bootstrap["SecretID"]
 
+
 @pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 7, 0), reason="Nomad dispatch not supported")
 @pytest.mark.run(order=1)
 def test_list_tokens(nomad_setup):
     assert "Bootstrap Token" in nomad_setup.acl.get_tokens()[0]["Name"]
+
 
 @pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 7, 0), reason="Nomad dispatch not supported")
 @pytest.mark.run(order=2)
@@ -27,11 +29,13 @@ def test_create_token(nomad_setup):
     created_token = nomad_setup.acl.create_token(json_token)
     assert "Readonly token" in created_token["Name"]
 
+
 @pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 7, 0), reason="Nomad dispatch not supported")
 @pytest.mark.run(order=3)
 def test_list_all_tokens(nomad_setup):
     tokens = nomad_setup.acl.get_tokens()
     assert isinstance(tokens, list)
+
 
 @pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 7, 0), reason="Nomad dispatch not supported")
 @pytest.mark.run(order=4)
@@ -45,6 +49,7 @@ def test_update_token(nomad_setup):
     update_token = nomad_setup.acl.update_token(id=created_token["AccessorID"],token=json_token_update)
     assert "Updated" in update_token["Name"]
 
+
 @pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 7, 0), reason="Nomad dispatch not supported")
 @pytest.mark.run(order=5)
 def test_get_token(nomad_setup):
@@ -54,6 +59,7 @@ def test_get_token(nomad_setup):
 
     get_token = nomad_setup.acl.get_token(created_token["AccessorID"])
     assert "GetToken" in created_token["Name"]
+
 
 @pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 7, 0), reason="Nomad dispatch not supported")
 @pytest.mark.run(order=6)
@@ -66,15 +72,18 @@ def test_delete_token(nomad_setup):
     nomad_setup.acl.delete_token(created_token["AccessorID"])
     assert False == any("DeleteToken" in x for x in nomad_setup.acl.get_tokens())
 
+
 @pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 7, 0), reason="Nomad dispatch not supported")
 def test_get_self_token(nomad_setup):
     current_token = nomad_setup.acl.get_self_token()
     assert nomad_setup.get_token() in current_token["SecretID"]
 
+
 @pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 7, 0), reason="Nomad dispatch not supported")
 def test_get_policies(nomad_setup):
     policies = nomad_setup.acl.get_policies()
     assert isinstance(policies, list)
+
 
 @pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 7, 0), reason="Nomad dispatch not supported")
 def test_create_policy(nomad_setup):
@@ -83,10 +92,12 @@ def test_create_policy(nomad_setup):
     nomad_setup.acl.create_policy(id="my-policy", policy=json_policy)
     assert False == any("my-policy" in x for x in nomad_setup.acl.get_policies())
 
+
 @pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 7, 0), reason="Nomad dispatch not supported")
 def test_get_policy(nomad_setup):
     policy = nomad_setup.acl.get_policy("my-policy")
     assert "This is a great policy" in policy["Description"]
+
 
 @pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 7, 0), reason="Nomad dispatch not supported")
 def test_update_policy(nomad_setup):
@@ -94,6 +105,7 @@ def test_update_policy(nomad_setup):
     json_policy_update = json.loads(policy_update)
     nomad_setup.acl.update_policy(id="my-policy", policy=json_policy_update)
     assert False == any("Updated" in x for x in nomad_setup.acl.get_policies())
+
 
 @pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 7, 0), reason="Nomad dispatch not supported")
 def test_delete_policy(nomad_setup):

--- a/tests/test_allocation.py
+++ b/tests/test_allocation.py
@@ -1,5 +1,6 @@
 import pytest
 import json
+import uuid
 
 
 # integration tests requires nomad Vagrant VM or Binary running
@@ -25,7 +26,7 @@ def test_dunder_getitem_exist(nomad_setup):
 def test_dunder_getitem_not_exist(nomad_setup):
 
     with pytest.raises(KeyError):  # restucture try/except/raises
-        j = nomad_setup.allocation["redis"]
+        j = nomad_setup.allocation[str(uuid.uuid4())]
 
 
 def test_dunder_contain_exists(nomad_setup):
@@ -35,7 +36,7 @@ def test_dunder_contain_exists(nomad_setup):
 
 def test_dunder_contain_not_exist(nomad_setup):
 
-    assert "redis" not in nomad_setup.allocation
+    assert str(uuid.uuid4()) not in nomad_setup.allocation
 
 
 def test_dunder_str(nomad_setup):

--- a/tests/test_allocations.py
+++ b/tests/test_allocations.py
@@ -1,4 +1,13 @@
+import json
 import pytest
+
+
+def test_register_job(nomad_setup):
+
+    with open("example.json") as fh:
+        job = json.loads(fh.read())
+        nomad_setup.job.register_job("example", job)
+        assert "example" in nomad_setup.job
 
 
 # integration tests requires nomad Vagrant VM or Binary running

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -35,11 +35,13 @@ def test_base_get_connnection_not_authorized():
         j = n.job.get_job("example")
 
 
+@responses.activate
 def test_base_use_address_instead_on_host_port():
     responses.add(
         responses.GET,
         'https://nomad.service.consul:4646/v1/jobs',
-        status=200
+        status=200,
+        json=[]
     )
 
     nomad_address = "https://nomad.service.consul:4646"

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -5,6 +5,25 @@ import os
 import responses
 
 
+def test_base_region_qs():
+    n = nomad.Nomad(host=common.IP, port=common.NOMAD_PORT, verify=False, token=common.NOMAD_TOKEN, region="random")
+    qs = n.jobs._query_string_builder("v1/jobs")
+
+    assert "region" in qs
+    assert qs["region"] == "random"
+
+
+def test_base_region_and_namespace_qs():
+    n = nomad.Nomad(host=common.IP, port=common.NOMAD_PORT, verify=False, token=common.NOMAD_TOKEN, region="random", namespace="test")
+    qs = n.jobs._query_string_builder("v1/jobs")
+
+    assert "region" in qs
+    assert qs["region"] == "random"
+
+    assert "namespace" in qs
+    assert qs["namespace"] == "test"
+
+
 # integration tests requires nomad Vagrant VM or Binary running
 def test_base_get_connection_error():
     n = nomad.Nomad(

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -2,7 +2,7 @@ import pytest
 import tests.common as common
 import nomad
 import os
-import requests_mock
+import responses
 
 
 # integration tests requires nomad Vagrant VM or Binary running
@@ -36,8 +36,12 @@ def test_base_get_connnection_not_authorized():
 
 
 def test_base_use_address_instead_on_host_port():
-    with requests_mock.Mocker() as m:
-        m.get('https://nomad.service.consul:4646/v1/jobs', text='[]')
-        nomad_address = "https://nomad.service.consul:4646"
-        n = nomad.Nomad(address=nomad_address, host=common.IP, port=common.NOMAD_PORT, verify=False, token=common.NOMAD_TOKEN)
-        n.jobs.get_jobs()
+    responses.add(
+        responses.GET,
+        'https://nomad.service.consul:4646/v1/jobs',
+        status=200
+    )
+
+    nomad_address = "https://nomad.service.consul:4646"
+    n = nomad.Nomad(address=nomad_address, host=common.IP, port=common.NOMAD_PORT, verify=False, token=common.NOMAD_TOKEN)
+    n.jobs.get_jobs()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -5,6 +5,8 @@ import os
 
 import nomad
 
+from flaky import flaky
+
 
 # integration tests requires nomad Vagrant VM or Binary running
 def test_register_job(nomad_setup):
@@ -30,6 +32,7 @@ def test_stat_stat_file(nomad_setup):
     f = nomad_setup.client.stat.stat_file(a)
 
 
+@flaky(max_runs=5, min_passes=1)
 @pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 5, 6), reason="Not supported in version")
 def test_cat_read_file(nomad_setup):
 
@@ -37,6 +40,7 @@ def test_cat_read_file(nomad_setup):
     f = nomad_setup.client.cat.read_file(a, "/redis/executor.out")
 
 
+@flaky(max_runs=5, min_passes=1)
 @pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 7, 1), reason="Not supported in version")
 def test_read_file_offset(nomad_setup):
 
@@ -50,6 +54,15 @@ def test_streamfile_fail(nomad_setup):
     with pytest.raises(nomad.api.exceptions.BadRequestNomadException):
         a = nomad_setup.allocations.get_allocations()[0]["ID"]
         _ = nomad_setup.client.streamfile.stream(a, 1, "start", "/redis/executor")  #invalid file name
+
+
+@flaky(max_runs=5, min_passes=1)
+@pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 8, 1), reason="Not supported in version")
+def test_streamlogs(nomad_setup):
+
+    a = nomad_setup.allocations.get_allocations()[0]["ID"]
+    _ = nomad_setup.client.streamlogs.stream(a, "redis", "stderr", False)
+
 
 
 @pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 5, 6), reason="Not supported in version")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -3,6 +3,8 @@ import json
 import time
 import os
 
+import nomad
+
 
 # integration tests requires nomad Vagrant VM or Binary running
 def test_register_job(nomad_setup):
@@ -12,7 +14,7 @@ def test_register_job(nomad_setup):
         nomad_setup.job.register_job("example", job)
         assert "example" in nomad_setup.job
 
-    time.sleep(15)
+    time.sleep(20)
 
 
 @pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 5, 6), reason="Not supported in version")
@@ -40,6 +42,14 @@ def test_read_file_offset(nomad_setup):
 
     a = nomad_setup.allocations.get_allocations()[0]["ID"]
     _ = nomad_setup.client.readat.read_file_offset(a, 1, 10, "/redis/executor.out")
+
+
+@pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 8, 1), reason="Not supported in version")
+def test_streamfile_fail(nomad_setup):
+
+    with pytest.raises(nomad.api.exceptions.BadRequestNomadException):
+        a = nomad_setup.allocations.get_allocations()[0]["ID"]
+        _ = nomad_setup.client.streamfile.stream(a, 1, "start", "/redis/executor")  #invalid file name
 
 
 @pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 5, 6), reason="Not supported in version")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -12,12 +12,11 @@ def test_register_job(nomad_setup):
         nomad_setup.job.register_job("example", job)
         assert "example" in nomad_setup.job
 
-    time.sleep(10)
+    time.sleep(15)
 
 
 @pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 5, 6), reason="Not supported in version")
 def test_ls_list_files(nomad_setup):
-    """Use Functioncal Test Instead"""
 
     a = nomad_setup.allocations.get_allocations()[0]["ID"]
     f = nomad_setup.client.ls.list_files(a)
@@ -25,15 +24,12 @@ def test_ls_list_files(nomad_setup):
 
 @pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 5, 6), reason="Not supported in version")
 def test_stat_stat_file(nomad_setup):
-    """Use Functioncal Test Instead"""
-
     a = nomad_setup.allocations.get_allocations()[0]["ID"]
     f = nomad_setup.client.stat.stat_file(a)
 
 
 @pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 5, 6), reason="Not supported in version")
 def test_cat_read_file(nomad_setup):
-    """Use Functioncal Test Instead"""
 
     a = nomad_setup.allocations.get_allocations()[0]["ID"]
     f = nomad_setup.client.cat.read_file(a, "/redis/executor.out")
@@ -41,14 +37,12 @@ def test_cat_read_file(nomad_setup):
 
 @pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 5, 6), reason="Not supported in version")
 def test_read_stats(nomad_setup):
-    """Use Functioncal Test Instead"""
 
     f = nomad_setup.client.stats.read_stats()
 
 
 @pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 5, 6), reason="Not supported in version")
 def test_read_allocation_stats(nomad_setup):
-    """Use Functioncal Test Instead"""
 
     a = nomad_setup.allocations.get_allocations()[0]["ID"]
     f = nomad_setup.client.allocation.read_allocation_stats(a)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -12,41 +12,41 @@ def test_register_job(nomad_setup):
 
 def test_ls_list_files(nomad_setup):
     """Use Functioncal Test Instead"""
-    # test_register_job(nomad_setup)
-    #
-    # a = nomad_setup.allocations.get_allocations()[0]["ID"]
-    # f = nomad_setup.client.ls.list_files(a)
+    test_register_job(nomad_setup)
+
+    a = nomad_setup.allocations.get_allocations()[0]["ID"]
+    f = nomad_setup.client.ls.list_files(a)
 
 
 def test_stat_stat_file(nomad_setup):
     """Use Functioncal Test Instead"""
-    # test_register_job(nomad_setup)
-    #
-    # a = nomad_setup.allocations.get_allocations()[0]["ID"]
-    # f = nomad_setup.client.stat.stat_file(a)
+    test_register_job(nomad_setup)
+
+    a = nomad_setup.allocations.get_allocations()[0]["ID"]
+    f = nomad_setup.client.stat.stat_file(a)
 
 
 def test_cat_read_file(nomad_setup):
     """Use Functioncal Test Instead"""
-    # test_register_job(nomad_setup)
-    #
-    # a = nomad_setup.allocations.get_allocations()[0]["ID"]
-    # f = nomad_setup.client.cat.read_file(a,"/redis/redis-executor.out")
+    test_register_job(nomad_setup)
+
+    a = nomad_setup.allocations.get_allocations()[0]["ID"]
+    f = nomad_setup.client.cat.read_file(a, "/redis/executor.out")
 
 
 def test_read_stats(nomad_setup):
     """Use Functioncal Test Instead"""
-    # test_register_job(nomad_setup)
-    #
-    # f = nomad_setup.client.stats.read_stats()
+    test_register_job(nomad_setup)
+
+    f = nomad_setup.client.stats.read_stats()
 
 
 def test_read_allocation_stats(nomad_setup):
     """Use Functioncal Test Instead"""
-    # test_register_job(nomad_setup)
-    #
-    # a = nomad_setup.allocations.get_allocations()[0]["ID"]
-    # f = nomad_setup.client.allocation.read_allocation(a)
+    test_register_job(nomad_setup)
+
+    a = nomad_setup.allocations.get_allocations()[0]["ID"]
+    f = nomad_setup.client.allocation.read_allocation_stats(a)
 
 
 def test_dunder_str(nomad_setup):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -45,7 +45,7 @@ def test_cat_read_file(nomad_setup):
 def test_read_file_offset(nomad_setup):
 
     a = nomad_setup.allocations.get_allocations()[0]["ID"]
-    _ = nomad_setup.client.readat.read_file_offset(a, 1, 10, "/redis/executor.out")
+    _ = nomad_setup.client.read_at.read_file_offset(a, 1, 10, "/redis/executor.out")
 
 
 @pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 8, 1), reason="Not supported in version")
@@ -53,7 +53,7 @@ def test_streamfile_fail(nomad_setup):
 
     with pytest.raises(nomad.api.exceptions.BadRequestNomadException):
         a = nomad_setup.allocations.get_allocations()[0]["ID"]
-        _ = nomad_setup.client.streamfile.stream(a, 1, "start", "/redis/executor")  #invalid file name
+        _ = nomad_setup.client.stream_file.stream(a, 1, "start", "/redis/executor")  #invalid file name
 
 
 @flaky(max_runs=5, min_passes=1)
@@ -61,8 +61,7 @@ def test_streamfile_fail(nomad_setup):
 def test_streamlogs(nomad_setup):
 
     a = nomad_setup.allocations.get_allocations()[0]["ID"]
-    _ = nomad_setup.client.streamlogs.stream(a, "redis", "stderr", False)
-
+    _ = nomad_setup.client.stream_logs.stream(a, "redis", "stderr", False)
 
 
 @pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 5, 6), reason="Not supported in version")
@@ -76,6 +75,14 @@ def test_read_allocation_stats(nomad_setup):
 
     a = nomad_setup.allocations.get_allocations()[0]["ID"]
     f = nomad_setup.client.allocation.read_allocation_stats(a)
+
+
+@pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 8, 1), reason="Not supported in version")
+def test_gc_allocation_fail(nomad_setup):
+
+    a = nomad_setup.allocations.get_allocations()[0]["ID"]
+    with pytest.raises(nomad.api.exceptions.URLNotFoundNomadException):
+        f = nomad_setup.client.gc_allocation.garbage_collect(a)  # attempt on non-stopped allocation
 
 
 def test_dunder_str(nomad_setup):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,6 +1,8 @@
 import pytest
 import json
 import time
+import os
+
 
 # integration tests requires nomad Vagrant VM or Binary running
 def test_register_job(nomad_setup):
@@ -13,6 +15,7 @@ def test_register_job(nomad_setup):
     time.sleep(10)
 
 
+@pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 5, 6), reason="Not supported in version")
 def test_ls_list_files(nomad_setup):
     """Use Functioncal Test Instead"""
 
@@ -20,6 +23,7 @@ def test_ls_list_files(nomad_setup):
     f = nomad_setup.client.ls.list_files(a)
 
 
+@pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 5, 6), reason="Not supported in version")
 def test_stat_stat_file(nomad_setup):
     """Use Functioncal Test Instead"""
 
@@ -27,6 +31,7 @@ def test_stat_stat_file(nomad_setup):
     f = nomad_setup.client.stat.stat_file(a)
 
 
+@pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 5, 6), reason="Not supported in version")
 def test_cat_read_file(nomad_setup):
     """Use Functioncal Test Instead"""
 
@@ -34,12 +39,14 @@ def test_cat_read_file(nomad_setup):
     f = nomad_setup.client.cat.read_file(a, "/redis/executor.out")
 
 
+@pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 5, 6), reason="Not supported in version")
 def test_read_stats(nomad_setup):
     """Use Functioncal Test Instead"""
 
     f = nomad_setup.client.stats.read_stats()
 
 
+@pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 5, 6), reason="Not supported in version")
 def test_read_allocation_stats(nomad_setup):
     """Use Functioncal Test Instead"""
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,5 +1,6 @@
 import pytest
 import json
+import time
 
 # integration tests requires nomad Vagrant VM or Binary running
 def test_register_job(nomad_setup):
@@ -9,10 +10,11 @@ def test_register_job(nomad_setup):
         nomad_setup.job.register_job("example", job)
         assert "example" in nomad_setup.job
 
+    time.sleep(3)
+
 
 def test_ls_list_files(nomad_setup):
     """Use Functioncal Test Instead"""
-    test_register_job(nomad_setup)
 
     a = nomad_setup.allocations.get_allocations()[0]["ID"]
     f = nomad_setup.client.ls.list_files(a)
@@ -20,7 +22,6 @@ def test_ls_list_files(nomad_setup):
 
 def test_stat_stat_file(nomad_setup):
     """Use Functioncal Test Instead"""
-    test_register_job(nomad_setup)
 
     a = nomad_setup.allocations.get_allocations()[0]["ID"]
     f = nomad_setup.client.stat.stat_file(a)
@@ -28,7 +29,6 @@ def test_stat_stat_file(nomad_setup):
 
 def test_cat_read_file(nomad_setup):
     """Use Functioncal Test Instead"""
-    test_register_job(nomad_setup)
 
     a = nomad_setup.allocations.get_allocations()[0]["ID"]
     f = nomad_setup.client.cat.read_file(a, "/redis/executor.out")
@@ -36,14 +36,12 @@ def test_cat_read_file(nomad_setup):
 
 def test_read_stats(nomad_setup):
     """Use Functioncal Test Instead"""
-    test_register_job(nomad_setup)
 
     f = nomad_setup.client.stats.read_stats()
 
 
 def test_read_allocation_stats(nomad_setup):
     """Use Functioncal Test Instead"""
-    test_register_job(nomad_setup)
 
     a = nomad_setup.allocations.get_allocations()[0]["ID"]
     f = nomad_setup.client.allocation.read_allocation_stats(a)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -10,7 +10,7 @@ def test_register_job(nomad_setup):
         nomad_setup.job.register_job("example", job)
         assert "example" in nomad_setup.job
 
-    time.sleep(3)
+    time.sleep(10)
 
 
 def test_ls_list_files(nomad_setup):

--- a/tests/test_deployments.py
+++ b/tests/test_deployments.py
@@ -1,5 +1,14 @@
+import json
 import pytest
 import os
+
+
+def test_register_job(nomad_setup):
+
+    with open("example.json") as fh:
+        job = json.loads(fh.read())
+        nomad_setup.job.register_job("example", job)
+        assert "example" in nomad_setup.job
 
 
 # integration tests requires nomad Vagrant VM or Binary running

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -1,4 +1,14 @@
+import json
 import pytest
+import uuid
+
+
+def test_register_job(nomad_setup):
+
+    with open("example.json") as fh:
+        job = json.loads(fh.read())
+        nomad_setup.job.register_job("example", job)
+        assert "example" in nomad_setup.job
 
 
 # integration tests requires nomad Vagrant VM or Binary running
@@ -24,7 +34,7 @@ def test_dunder_getitem_exist(nomad_setup):
 def test_dunder_getitem_not_exist(nomad_setup):
 
     with pytest.raises(KeyError):
-        _ = nomad_setup.evaluation["nope"]
+        _ = nomad_setup.evaluation[str(uuid.uuid4())]
 
 
 def test_dunder_contain_exists(nomad_setup):
@@ -33,7 +43,7 @@ def test_dunder_contain_exists(nomad_setup):
 
 
 def test_dunder_contain_not_exist(nomad_setup):
-    assert "nope" not in nomad_setup.evaluation
+    assert str(uuid.uuid4()) not in nomad_setup.evaluation
 
 
 def test_dunder_str(nomad_setup):

--- a/tests/test_evaluations.py
+++ b/tests/test_evaluations.py
@@ -1,4 +1,13 @@
+import json
 import pytest
+
+
+def test_register_job(nomad_setup):
+
+    with open("example.json") as fh:
+        job = json.loads(fh.read())
+        nomad_setup.job.register_job("example", job)
+        assert "example" in nomad_setup.job
 
 
 # integration tests requires nomad Vagrant VM or Binary running

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -57,34 +57,6 @@ def test_dispatch_job(nomad_setup):
 
 
 @pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 5, 3), reason="Nomad dispatch not supported")
-def test_dispatch_job_payload_string(nomad_setup):
-    with open("example_batch_parameterized.json") as fh:
-        job = json.loads(fh.read())
-        nomad_setup.job.register_job("example-batch", job)
-    try:
-        nomad_setup.job.dispatch_job("example-batch", payload="test", meta={"time": "500"})
-    except (exceptions.URLNotFoundNomadException,
-            exceptions.BaseNomadException) as e:
-        print(e.nomad_resp.text)
-        raise e
-    assert "example-batch" in nomad_setup.job
-
-
-@pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 5, 3), reason="Nomad dispatch not supported")
-def test_dispatch_job(nomad_setup):
-    with open("example_batch_parameterized.json") as fh:
-        job = json.loads(fh.read())
-        nomad_setup.job.register_job("example-batch", job)
-    try:
-        nomad_setup.job.dispatch_job("example-batch", meta={"time": "500"})
-    except (exceptions.URLNotFoundNomadException,
-            exceptions.BaseNomadException) as e:
-        print(e.nomad_resp.text)
-        raise e
-    assert "example-batch" in nomad_setup.job
-
-
-@pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 5, 3), reason="Nomad dispatch not supported")
 def test_summary_job(nomad_setup):
     j = nomad_setup.job["example"]
     assert "JobID" in nomad_setup.job.get_summary(j["ID"])

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -57,6 +57,34 @@ def test_dispatch_job(nomad_setup):
 
 
 @pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 5, 3), reason="Nomad dispatch not supported")
+def test_dispatch_job_payload_string(nomad_setup):
+    with open("example_batch_parameterized.json") as fh:
+        job = json.loads(fh.read())
+        nomad_setup.job.register_job("example-batch", job)
+    try:
+        nomad_setup.job.dispatch_job("example-batch", payload="test", meta={"time": "500"})
+    except (exceptions.URLNotFoundNomadException,
+            exceptions.BaseNomadException) as e:
+        print(e.nomad_resp.text)
+        raise e
+    assert "example-batch" in nomad_setup.job
+
+
+@pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 5, 3), reason="Nomad dispatch not supported")
+def test_dispatch_job(nomad_setup):
+    with open("example_batch_parameterized.json") as fh:
+        job = json.loads(fh.read())
+        nomad_setup.job.register_job("example-batch", job)
+    try:
+        nomad_setup.job.dispatch_job("example-batch", meta={"time": "500"})
+    except (exceptions.URLNotFoundNomadException,
+            exceptions.BaseNomadException) as e:
+        print(e.nomad_resp.text)
+        raise e
+    assert "example-batch" in nomad_setup.job
+
+
+@pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 5, 3), reason="Nomad dispatch not supported")
 def test_summary_job(nomad_setup):
     j = nomad_setup.job["example"]
     assert "JobID" in nomad_setup.job.get_summary(j["ID"])

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -4,10 +4,6 @@ import json
 
 
 # integration tests requires nomad Vagrant VM or Binary running
-def test_get_jobs(nomad_setup):
-    assert isinstance(nomad_setup.jobs.get_jobs(), list) == True
-
-
 def test_register_job(nomad_setup):
 
     with open("example.json") as fh:
@@ -16,9 +12,12 @@ def test_register_job(nomad_setup):
         assert "example" in nomad_setup.jobs
 
 
+def test_get_jobs(nomad_setup):
+    assert isinstance(nomad_setup.jobs.get_jobs(), list) == True
+
+
 @pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 8, 3), reason="Not supported in version")
 def test_parse_job(nomad_setup):
-
     with open("example.nomad") as fh:
         hcl = fh.read()
         json_dict = nomad_setup.jobs.parse(hcl)

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -1,36 +1,61 @@
+import tests.common as common
+
 import json
-from mock import patch, MagicMock
-import requests
+
+import responses
 
 
+@responses.activate
+def test_create_namespace(nomad_setup):
 
-# integration tests was mocked. If you have an enterprise nomad please uncomenet ##### ENTERPRISE TEST #####
-@patch('nomad.api.namespace.Namespace._post')
-def test_create_namespace(mock_post, nomad_setup):
-    mock_post.return_value = requests.codes.ok
-    namespace_api='{"Name":"api","Description":"api server namespace"}'
+        responses.add(
+            responses.POST,
+            "http://{ip}:{port}/v1/namespace".format(ip=common.IP, port=common.NOMAD_PORT),
+            status=200
+        )
+
+        namespace_api = '{"Name":"api","Description":"api server namespace"}'
+        namespace = json.loads(namespace_api)
+        nomad_setup.namespace.create_namespace(namespace)
+
+
+@responses.activate
+def test_update_namespace(nomad_setup):
+
+    responses.add(
+        responses.POST,
+        "http://{ip}:{port}/v1/namespace/api".format(ip=common.IP, port=common.NOMAD_PORT),
+        status=200
+    )
+
+    namespace_api = '{"Name":"api","Description":"updated namespace"}'
     namespace = json.loads(namespace_api)
-    assert 200 == nomad_setup.namespace.create_namespace(namespace)
+    nomad_setup.namespace.update_namespace("api", namespace)
 
 
-@patch('nomad.api.namespace.Namespace._post')
-def test_update_namespace(mock_post, nomad_setup):
-    mock_post.return_value = requests.codes.ok
-    namespace_api='{"Name":"api","Description":"updated namespace"}'
-    namespace = json.loads(namespace_api)
-    assert 200 == nomad_setup.namespace.update_namespace("api", namespace)
+@responses.activate
+def test_get_namespace(nomad_setup):
 
+    responses.add(
+        responses.GET,
+        "http://{ip}:{port}/v1/namespace/api".format(ip=common.IP, port=common.NOMAD_PORT),
+        status=200,
+        json={"Name": "api", "Description": "api server namespace"}
+    )
 
-@patch('nomad.api.namespace.Namespace._get')
-def test_get_namespace(mock_get, nomad_setup):
-    mock_get.return_value = {"Name":"api","Description":"api server namespace"}
     assert "api" in nomad_setup.namespace.get_namespace("api")["Name"]
 
-@patch('nomad.api.namespace.Namespace._delete')
-def test_delete_namespace(mock_delete, nomad_setup):
-    mock_delete.return_value = {"Name":"api","Description":"api server namespace"}
+
+@responses.activate
+def test_delete_namespace(nomad_setup):
+    responses.add(
+        responses.DELETE,
+        "http://{ip}:{port}/v1/namespace/api".format(ip=common.IP, port=common.NOMAD_PORT),
+        status=200,
+    )
+
     nomad_setup.namespace.delete_namespace("api")
-    assert "api" == nomad_setup.namespace.delete_namespace("api")["Name"]
+
 
 
 ######### ENTERPRISE TEST ###########

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -12,6 +12,7 @@ def test_create_namespace(mock_post, nomad_setup):
     namespace = json.loads(namespace_api)
     assert 200 == nomad_setup.namespace.create_namespace(namespace)
 
+
 @patch('nomad.api.namespace.Namespace._post')
 def test_update_namespace(mock_post, nomad_setup):
     mock_post.return_value = requests.codes.ok

--- a/tests/test_namespaces.py
+++ b/tests/test_namespaces.py
@@ -1,62 +1,83 @@
-from mock import patch, MagicMock
+import tests.common as common
+
+import pytest
+import responses
 
 
 # integration tests was mocked. If you have an enterprise nomad please uncomenet ##### ENTERPRISE TEST #####
-@patch('nomad.api.namespaces.Namespaces._get')
-def test_get_namespaces(mock_get, nomad_setup):
-    mock_get.return_value = [
-                                {
-                                    "CreateIndex": 31,
-                                    "Description": "Production API Servers",
-                                    "ModifyIndex": 31,
-                                    "Name": "api-prod"
-                                },
-                                {
-                                    "CreateIndex": 5,
-                                    "Description": "Default shared namespace",
-                                    "ModifyIndex": 5,
-                                    "Name": "default"
-                                }
-                            ]
+@responses.activate
+def test_get_namespaces(nomad_setup):
+    responses.add(
+        responses.GET,
+        "http://{ip}:{port}/v1/namespaces".format(ip=common.IP, port=common.NOMAD_PORT),
+        status=200,
+        json=[
+                {
+                    "CreateIndex": 31,
+                    "Description": "Production API Servers",
+                    "ModifyIndex": 31,
+                    "Name": "api-prod"
+                },
+                {
+                    "CreateIndex": 5,
+                    "Description": "Default shared namespace",
+                    "ModifyIndex": 5,
+                    "Name": "default"
+                }
+            ]
+    )
+
     assert isinstance(nomad_setup.namespaces.get_namespaces(), list) == True
 
-@patch('nomad.api.namespaces.Namespaces._get')
-def test_namespaces_iter_(mock_get, nomad_setup):
-    mock_get.return_value = [
-                                {
-                                    "CreateIndex": 31,
-                                    "Description": "Production API Servers",
-                                    "ModifyIndex": 31,
-                                    "Name": "api-prod"
-                                },
-                                {
-                                    "CreateIndex": 5,
-                                    "Description": "Default shared namespace",
-                                    "ModifyIndex": 5,
-                                    "Name": "default"
-                                }
-                            ]
+
+@responses.activate
+def test_namespaces_iter(nomad_setup):
+    responses.add(
+        responses.GET,
+        "http://{ip}:{port}/v1/namespaces".format(ip=common.IP, port=common.NOMAD_PORT),
+        status=200,
+        json=[
+                {
+                    "CreateIndex": 31,
+                    "Description": "Production API Servers",
+                    "ModifyIndex": 31,
+                    "Name": "api-prod"
+                },
+                {
+                    "CreateIndex": 5,
+                    "Description": "Default shared namespace",
+                    "ModifyIndex": 5,
+                    "Name": "default"
+                }
+            ]
+    )
+
     assert "api-prod" in nomad_setup.namespaces
 
-@patch('nomad.api.namespaces.Namespaces._get')
-def test_namespaces_len_(mock_get, nomad_setup):
-    mock_get.return_value = [
-                                {
-                                    "CreateIndex": 31,
-                                    "Description": "Production API Servers",
-                                    "ModifyIndex": 31,
-                                    "Name": "api-prod"
-                                },
-                                {
-                                    "CreateIndex": 5,
-                                    "Description": "Default shared namespace",
-                                    "ModifyIndex": 5,
-                                    "Name": "default"
-                                }
-                            ]
-    assert 2 == nomad_setup.namespaces.__len__()
 
+@responses.activate
+def test_namespaces_len(nomad_setup):
+    responses.add(
+        responses.GET,
+        "http://{ip}:{port}/v1/namespaces".format(ip=common.IP, port=common.NOMAD_PORT),
+        status=200,
+        json=[
+                {
+                    "CreateIndex": 31,
+                    "Description": "Production API Servers",
+                    "ModifyIndex": 31,
+                    "Name": "api-prod"
+                },
+                {
+                    "CreateIndex": 5,
+                    "Description": "Default shared namespace",
+                    "ModifyIndex": 5,
+                    "Name": "default"
+                }
+            ]
+    )
 
+    assert 2 == len(nomad_setup.namespaces)
 
 
 ###### ENTERPRISE TEST ###########

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -1,5 +1,7 @@
 import os
 import pytest
+import uuid
+
 from nomad.api import exceptions as nomad_exceptions
 
 
@@ -65,7 +67,7 @@ def test_dunder_getitem_exist(nomad_setup):
 def test_dunder_getitem_not_exist(nomad_setup):
 
     with pytest.raises(KeyError):
-        _ = nomad_setup.node["pynomad2"]
+        _ = nomad_setup.node[str(uuid.uuid4())]
 
 
 def test_dunder_contain_exists(nomad_setup):
@@ -74,7 +76,7 @@ def test_dunder_contain_exists(nomad_setup):
 
 
 def test_dunder_contain_not_exist(nomad_setup):
-    assert "pynomad2" not in nomad_setup.node
+    assert str(uuid.uuid4()) not in nomad_setup.node
 
 
 def test_dunder_str(nomad_setup):

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -16,7 +16,7 @@ def test_get_configuration_stale(nomad_setup):
 
 @pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 5, 5), reason="Not supported in version")
 def test_delete_peer(nomad_setup):
-    with pytest.raises(exceptions.URLNotFoundNomadException):
+    with pytest.raises(exceptions.BaseNomadException):
         nomad_setup.operator.delete_peer("192.168.33.10:4646")
 
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -14,7 +14,7 @@ def test_validate_job(nomad_setup):
 # integration tests requires nomad Vagrant VM or Binary running
 @pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 6, 0), reason="Not supported in version")
 def test_invalid_job(nomad_setup):
-    with pytest.raises(nomad.api.exceptions.URLNotFoundNomadException):
+    with pytest.raises(nomad.api.exceptions.BadRequestNomadException):
         nomad_setup.validate.validate_job({})
 
 


### PR DESCRIPTION
Restructure base Requester class, inherit from class instead of passing object to each instantiation. Removes all helpers `_get, _post, _no_post, _put, _delete` in each endpoint. Additional exceptions for status_codes. Should address:

- #42
- #59
- #62
- #64 

Exceptions that occur from communication with the Nomad API should now be following based on the status codes from, and inherit from `BaseNomadException`:
- https://www.nomadproject.io/api/index.html#http-response-codes

Additional endpoints for client:
- read_at
- stream_file
- stream_logs
- gc_allocate
- gc_all

This change is a breaking change along with some methods in the __init__ being removed:
- set_namespace
- set_token