### PR TITLE
Added support for optional `purge` parameter in job.deregister.

### DIFF
--- a/docs/api/job.md
+++ b/docs/api/job.md
@@ -502,7 +502,7 @@ This endpoint deregisters a job, and stops all allocations part of it.
 
 https://www.nomadproject.io/api/jobs.html#stop-a-job
 
-Example:
+Example of deferred removal of job (performed by Nomad garbage collector):
 
 ```
 import nomad
@@ -510,4 +510,14 @@ import nomad
 my_nomad = nomad.Nomad(host='192.168.33.10')
 
 my_nomad.job.deregister_job("example")
+```
+
+Example of immediate removal of job (job not queryable after this):
+
+```
+import nomad
+
+my_nomad = nomad.Nomad(host='192.168.33.10')
+
+my_nomad.job.deregister_job("example", purge=True)
 ```

--- a/nomad/api/job.py
+++ b/nomad/api/job.py
@@ -271,16 +271,27 @@ class Job(Requester):
                        "Stable": stable}
         return self.request(id, "stable", json=revert_json, method="post").json()
 
-    def deregister_job(self, id):
+    def deregister_job(self, id, purge=None):
         """ Deregisters a job, and stops all allocations part of it.
 
            https://www.nomadproject.io/docs/http/job.html
 
             arguments:
               - id
+              - purge (bool), optionally specifies whether the job should be
+                stopped and purged immediately (`purge=True`) or deferred to the
+                Nomad garbage collector (`purge=False`).
+
             returns: dict
             raises:
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
+              - nomad.api.exceptions.InvalidParameters
         """
-        return self.request(id, method="delete").json()
+        params = None
+        if purge is not None:
+            if not isinstance(purge, bool):
+                raise nomad.api.exceptions.InvalidParameters("purge is invalid "
+                        "(expected type %s but got %s)"%(type(bool()), type(purge)))
+            params = {"purge": purge}
+        return self.request(id, params=params, method="delete").json()

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -145,3 +145,19 @@ def test_dunder_getattr(nomad_setup):
 
     with pytest.raises(AttributeError):
         d = nomad_setup.job.does_not_exist
+
+def test_delete_job_with_invalid_purge_param_raises(nomad_setup):
+    with pytest.raises(exceptions.InvalidParameters):
+       nomad_setup.job.deregister_job("example", purge='True')
+
+def test_delete_job_with_purge(nomad_setup):
+    # Run this last since it will purge the job completely, resetting things like
+    # job version
+    assert "EvalID" in nomad_setup.job.deregister_job("example", purge=True)
+
+    # Job should not be available after a purge.
+    with pytest.raises(exceptions.URLNotFoundNomadException):
+        nomad_setup.job.get_job("example")
+
+    # Reregister job
+    test_register_job(nomad_setup)


### PR DESCRIPTION
I use python-nomad for our integration tests, and for that I want to clean up properly which means to remove all traces of jobs after the test run. Nomad supports this with the optional `purge` parameter which I now added.

Looking at the test implementation it looks like the tests have ordering dependencies (`test_delete_job` is re-registering the job afterwards) so I added the test which purges at the bottom and finally also reregister the job. If subsequent tests depend on a built up state (job versions for example), this could lead to issues down the line.