### PR TITLE
RFC: Blocking queries index param

### DIFF
--- a/nomad/api/acl.py
+++ b/nomad/api/acl.py
@@ -37,10 +37,13 @@ class Acl(Requester):
         """
         return self.request("bootstrap", method="post").json()
 
-    def get_tokens(self):
+    def get_tokens(self, index=None):
         """ Get a list of tokens.
 
             https://www.nomadproject.io/api/acl-tokens.html
+
+            optional_arguments:
+              - index  :(dict) optional, provides a dictionary for keeping track of x-nomad-index
 
             returns: list
 
@@ -49,33 +52,39 @@ class Acl(Requester):
               - nomad.api.exceptions.URLNotFoundNomadException
         """
 
-        return self.request("tokens", method="get").json()
+        return self.request("tokens", method="get", index=index).json()
 
-    def get_token(self, id):
+    def get_token(self, id, index=None):
         """ Retrieve specific token.
 
             https://www.nomadproject.io/api/acl-tokens.html
 
+            optional_arguments:
+              - index  :(dict) optional, provides a dictionary for keeping track of x-nomad-index
+
             returns: dict
 
             raises:
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self.request("token", id, method="get").json()
+        return self.request("token", id, method="get", index=index).json()
 
-    def get_self_token(self):
+    def get_self_token(self, index=None):
         """ Retrieve self token used for auth.
 
             https://www.nomadproject.io/api/acl-tokens.html
 
+            optional_arguments:
+              - index  :(dict) optional, provides a dictionary for keeping track of x-nomad-index
+
             returns: dict
 
             raises:
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self.request("token", "self", method="get").json()
+        return self.request("token", "self", method="get", index=index).json()
 
     def create_token(self, token):
         """ Create token.

--- a/nomad/api/allocation.py
+++ b/nomad/api/allocation.py
@@ -44,14 +44,17 @@ class Allocation(Requester):
         except nomad.api.exceptions.URLNotFoundNomadException:
             raise KeyError
 
-    def get_allocation(self, id):
+    def get_allocation(self, id, index=None):
         """ Query a specific allocation.
 
            https://www.nomadproject.io/docs/http/alloc.html
 
+            arguments:
+              - id
+              - index  :(dict) optional, provides a dictionary for keeping track of x-nomad-index
             returns: dict
             raises:
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self.request(id, method="get").json()
+        return self.request(id, method="get", index=index).json()

--- a/nomad/api/allocations.py
+++ b/nomad/api/allocations.py
@@ -32,17 +32,18 @@ class Allocations(Requester):
         response = self.get_allocations()
         return iter(response)
 
-    def get_allocations(self, prefix=None):
+    def get_allocations(self, prefix=None, index=None):
         """ Lists all the allocations.
 
            https://www.nomadproject.io/docs/http/allocs.html
             arguments:
               - prefix :(str) optional, specifies a string to filter allocations on based on an prefix.
                         This is specified as a querystring parameter.
+              - index  :(dict) optional, provides a dictionary for keeping track of x-nomad-index
             returns: list
             raises:
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
         params = {"prefix": prefix}
-        return self.request(method="get", params=params).json()
+        return self.request(method="get", params=params, index=index).json()

--- a/nomad/api/base.py
+++ b/nomad/api/base.py
@@ -10,7 +10,7 @@ class Requester(object):
 
     ENDPOINT = ""
 
-    def __init__(self, address=None, uri='http://127.0.0.1', port=4646, namespace=None, token=None, timeout=5, blocking_timeout=300, version='v1', verify=False, cert=(), region=None, **kwargs):
+    def __init__(self, address=None, uri='http://127.0.0.1', port=4646, namespace=None, token=None, timeout=5, blocking_timeout=360, version='v1', verify=False, cert=(), region=None, **kwargs):
         self.uri = uri
         self.port = port
         self.namespace = namespace
@@ -109,7 +109,7 @@ class Requester(object):
         try:
             method = method.lower()
             if method == "get":
-                timeout = blocking_timeout if index else timeout
+                timeout = self.blocking_timeout if index else self.timeout
                 response = self.session.get(
                     url=url,
                     params=params,

--- a/nomad/api/base.py
+++ b/nomad/api/base.py
@@ -101,7 +101,7 @@ class Requester(object):
                 headers = {"X-Nomad-Token": self.token}
 
         if index and index.get("X-Nomad-Index"):
-            headers["X-Nomad-Index"] = index["X-Nomad-Index"]
+            params["index"] = index["X-Nomad-Index"]
 
         response = None
 

--- a/nomad/api/base.py
+++ b/nomad/api/base.py
@@ -79,12 +79,13 @@ class Requester(object):
             data=kwargs.get("data", None),
             json=kwargs.get("json", None),
             headers=kwargs.get("headers", None),
-            allow_redirects=kwargs.get("allow_redirects", False)
+            allow_redirects=kwargs.get("allow_redirects", False),
+            index=kwargs.get("index", None)
         )
 
         return response
 
-    def _request(self, method, endpoint, params=None, data=None, json=None, headers=None, allow_redirects=None):
+    def _request(self, method, endpoint, params=None, data=None, json=None, headers=None, allow_redirects=None, index=None):
         url = self._url_builder(endpoint)
         qs = self._query_string_builder(endpoint)
 
@@ -98,6 +99,9 @@ class Requester(object):
                 headers["X-Nomad-Token"] = self.token
             except TypeError:
                 headers = {"X-Nomad-Token": self.token}
+
+        if index and index.get("X-Nomad-Index"):
+            headers["X-Nomad-Index"] = index["X-Nomad-Index"]
 
         response = None
 
@@ -148,6 +152,8 @@ class Requester(object):
                 )
 
             if response.ok:
+                if index:
+                    index["X-Nomad-Index"] = response.headers["X-Nomad-Index"]
                 return response
             elif response.status_code == 400:
                 raise nomad.api.exceptions.BadRequestNomadException(response)

--- a/nomad/api/base.py
+++ b/nomad/api/base.py
@@ -154,7 +154,7 @@ class Requester(object):
                 )
 
             if response.ok:
-                if index:
+                if index is not None:
                     index["X-Nomad-Index"] = response.headers["X-Nomad-Index"]
                 return response
             elif response.status_code == 400:

--- a/nomad/api/base.py
+++ b/nomad/api/base.py
@@ -10,12 +10,13 @@ class Requester(object):
 
     ENDPOINT = ""
 
-    def __init__(self, address=None, uri='http://127.0.0.1', port=4646, namespace=None, token=None, timeout=5, version='v1', verify=False, cert=(), region=None, **kwargs):
+    def __init__(self, address=None, uri='http://127.0.0.1', port=4646, namespace=None, token=None, timeout=5, blocking_timeout=300, version='v1', verify=False, cert=(), region=None, **kwargs):
         self.uri = uri
         self.port = port
         self.namespace = namespace
         self.token = token
         self.timeout = timeout
+        self.blocking_timeout = blocking_timeout
         self.version = version
         self.verify = verify
         self.cert = cert
@@ -108,11 +109,12 @@ class Requester(object):
         try:
             method = method.lower()
             if method == "get":
+                timeout = blocking_timeout if index else timeout
                 response = self.session.get(
                     url=url,
                     params=params,
                     headers=headers,
-                    timeout=self.timeout,
+                    timeout=timeout,
                     verify=self.verify,
                     cert=self.cert,
                     allow_redirects=allow_redirects

--- a/nomad/api/deployment.py
+++ b/nomad/api/deployment.py
@@ -43,33 +43,35 @@ class Deployment(Requester):
         except nomad.api.exceptions.URLNotFoundNomadException:
             raise KeyError
 
-    def get_deployment(self, id):
+    def get_deployment(self, id, index=None):
         """ This endpoint reads information about a specific deployment by ID.
 
            https://www.nomadproject.io/docs/http/deployments.html
 
             arguments:
               - id
+              - index  :(dict) optional, provides a dictionary for keeping track of x-nomad-index
             returns: dict
             raises:
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self.request(id, method="get").json()
+        return self.request(id, method="get", index=index).json()
 
-    def get_deployment_allocations(self, id):
+    def get_deployment_allocations(self, id, index=None):
         """ This endpoint lists the allocations created or modified for the given deployment.
 
            https://www.nomadproject.io/docs/http/deployments.html
 
             arguments:
               - id
+              - index  :(dict) optional, provides a dictionary for keeping track of x-nomad-index
             returns: list of dicts
             raises:
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self.request("allocations", id, method="get").json()
+        return self.request("allocations", id, method="get", index=index).json()
 
     def fail_deployment(self, id):
         """ This endpoint is used to mark a deployment as failed. This should be done to force the scheduler to stop

--- a/nomad/api/deployments.py
+++ b/nomad/api/deployments.py
@@ -56,7 +56,7 @@ class Deployments(Requester):
         except nomad.api.exceptions.URLNotFoundNomadException:
             raise KeyError
 
-    def get_deployments(self, prefix=""):
+    def get_deployments(self, prefix="", index=None):
         """ This endpoint lists all deployments.
 
            https://www.nomadproject.io/docs/http/deployments.html
@@ -64,6 +64,8 @@ class Deployments(Requester):
             optional_arguments:
               - prefix, (default "") Specifies a string to filter deployments on based on an index prefix.
                         This is specified as a querystring parameter.
+              - index  :(dict) optional, provides a dictionary for keeping track of x-nomad-index
+
 
             returns: list of dicts
             raises:

--- a/nomad/api/evaluation.py
+++ b/nomad/api/evaluation.py
@@ -45,13 +45,14 @@ class Evaluation(Requester):
         except nomad.api.exceptions.URLNotFoundNomadException:
             raise KeyError
 
-    def get_evaluation(self, id):
+    def get_evaluation(self, id, index=None):
         """ Query a specific evaluation.
 
            https://www.nomadproject.io/docs/http/eval.html
 
             arguments:
               - id
+              - index  :(dict) optional, provides a dictionary for keeping track of x-nomad-index
             returns: dict
             raises:
               - nomad.api.exceptions.BaseNomadException
@@ -59,16 +60,17 @@ class Evaluation(Requester):
         """
         return self.request(id, method="get").json()
 
-    def get_allocations(self, id):
+    def get_allocations(self, id, index=None):
         """ Query the allocations created or modified by an evaluation.
 
            https://www.nomadproject.io/docs/http/eval.html
 
             arguments:
               - id
+              - index  :(dict) optional, provides a dictionary for keeping track of x-nomad-index
             returns: list
             raises:
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self.request(id, "allocations", method="get").json()
+        return self.request(id, "allocations", method="get", index=index).json()

--- a/nomad/api/evaluations.py
+++ b/nomad/api/evaluations.py
@@ -57,17 +57,18 @@ class Evaluations(Requester):
         evaluations = self.get_evaluations()
         return iter(evaluations)
 
-    def get_evaluations(self, prefix=None):
+    def get_evaluations(self, prefix=None, index=None):
         """ Lists all the evaluations.
 
            https://www.nomadproject.io/docs/http/evals.html
             arguments:
               - prefix :(str) optional, specifies a string to filter evaluations on based on an prefix.
                         This is specified as a querystring parameter.
+              - index  :(dict) optional, provides a dictionary for keeping track of x-nomad-index
             returns: list
             raises:
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
         params = {"prefix": prefix}
-        return self.request(method="get", params=params).json()
+        return self.request(method="get", params=params, index=index).json()

--- a/nomad/api/job.py
+++ b/nomad/api/job.py
@@ -48,7 +48,7 @@ class Job(Requester):
         except nomad.api.exceptions.URLNotFoundNomadException:
             raise KeyError
 
-    def get_job(self, id, link=None):
+    def get_job(self, id, index=None):
         """ Query a single job for its specification and status.
 
            https://www.nomadproject.io/docs/http/job.html
@@ -61,9 +61,9 @@ class Job(Requester):
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self.request(id, method="get", link=link).json()
+        return self.request(id, method="get", index=index).json()
 
-    def get_versions(self, id, link=None):
+    def get_versions(self, id, index=None):
         """ This endpoint reads information about all versions of a job.
 
            https://www.nomadproject.io/docs/http/job.html
@@ -76,9 +76,9 @@ class Job(Requester):
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self.request(id, "versions", method="get", link=link).json()
+        return self.request(id, "versions", method="get", index=index).json()
 
-    def get_allocations(self, id, link=None):
+    def get_allocations(self, id, index=None):
         """ Query the allocations belonging to a single job.
 
            https://www.nomadproject.io/docs/http/job.html
@@ -91,9 +91,9 @@ class Job(Requester):
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self.request(id, "allocations", method="get", link=link).json()
+        return self.request(id, "allocations", method="get", index=index).json()
 
-    def get_evaluations(self, id, link=None):
+    def get_evaluations(self, id, index=None):
         """ Query the evaluations belonging to a single job.
 
            https://www.nomadproject.io/docs/http/job.html
@@ -106,9 +106,9 @@ class Job(Requester):
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self.request(id, "evaluations", method="get", link=link).json()
+        return self.request(id, "evaluations", method="get", index=index).json()
 
-    def get_deployments(self, id, link=None):
+    def get_deployments(self, id, index=None):
         """ This endpoint lists a single job's deployments
 
            https://www.nomadproject.io/docs/http/job.html
@@ -121,9 +121,9 @@ class Job(Requester):
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self.request(id, "deployments", method="get", link=link).json()
+        return self.request(id, "deployments", method="get", index=index).json()
 
-    def get_deployment(self, id, link=None):
+    def get_deployment(self, id, index=None):
         """ This endpoint returns a single job's most recent deployment.
 
            https://www.nomadproject.io/docs/http/job.html
@@ -136,9 +136,9 @@ class Job(Requester):
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self.request(id, "deployment", method="get", link=link).json()
+        return self.request(id, "deployment", method="get", index=index).json()
 
-    def get_summary(self, id, link=None):
+    def get_summary(self, id, index=None):
         """ Query the summary of a job.
 
            https://www.nomadproject.io/docs/http/job.html
@@ -151,7 +151,7 @@ class Job(Requester):
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self.request(id, "summary", method="get", link=link).json()
+        return self.request(id, "summary", method="get", index=index).json()
 
     def register_job(self, id, job):
         """ Registers a new job or updates an existing job

--- a/nomad/api/job.py
+++ b/nomad/api/job.py
@@ -48,103 +48,110 @@ class Job(Requester):
         except nomad.api.exceptions.URLNotFoundNomadException:
             raise KeyError
 
-    def get_job(self, id):
+    def get_job(self, id, link=None):
         """ Query a single job for its specification and status.
 
            https://www.nomadproject.io/docs/http/job.html
 
             arguments:
               - id
+              - index  :(dict) optional, provides a dictionary for keeping track of x-nomad-index
             returns: dict
             raises:
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self.request(id, method="get").json()
+        return self.request(id, method="get", link=link).json()
 
-    def get_versions(self, id):
+    def get_versions(self, id, link=None):
         """ This endpoint reads information about all versions of a job.
 
            https://www.nomadproject.io/docs/http/job.html
 
             arguments:
               - id
+              - index  :(dict) optional, provides a dictionary for keeping track of x-nomad-index
             returns: list of dicts
             raises:
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self.request(id, "versions", method="get").json()
+        return self.request(id, "versions", method="get", link=link).json()
 
-    def get_allocations(self, id):
+    def get_allocations(self, id, link=None):
         """ Query the allocations belonging to a single job.
 
            https://www.nomadproject.io/docs/http/job.html
 
             arguments:
               - id
+              - index  :(dict) optional, provides a dictionary for keeping track of x-nomad-index
             returns: list
             raises:
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self.request(id, "allocations", method="get").json()
+        return self.request(id, "allocations", method="get", link=link).json()
 
-    def get_evaluations(self, id):
+    def get_evaluations(self, id, link=None):
         """ Query the evaluations belonging to a single job.
 
            https://www.nomadproject.io/docs/http/job.html
 
             arguments:
               - id
+              - index  :(dict) optional, provides a dictionary for keeping track of x-nomad-index
             returns: dict
             raises:
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self.request(id, "evaluations", method="get").json()
+        return self.request(id, "evaluations", method="get", link=link).json()
 
-    def get_deployments(self, id):
+    def get_deployments(self, id, link=None):
         """ This endpoint lists a single job's deployments
 
            https://www.nomadproject.io/docs/http/job.html
 
             arguments:
               - id
+              - index  :(dict) optional, provides a dictionary for keeping track of x-nomad-index
             returns: dict
             raises:
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self.request(id, "deployments", method="get").json()
+        return self.request(id, "deployments", method="get", link=link).json()
 
-    def get_deployment(self, id):
+    def get_deployment(self, id, link=None):
         """ This endpoint returns a single job's most recent deployment.
 
            https://www.nomadproject.io/docs/http/job.html
 
             arguments:
               - id
+              - index  :(dict) optional, provides a dictionary for keeping track of x-nomad-index
             returns: list of dicts
             raises:
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self.request(id, "deployment", method="get").json()
+        return self.request(id, "deployment", method="get", link=link).json()
 
-    def get_summary(self, id):
+    def get_summary(self, id, link=None):
         """ Query the summary of a job.
 
            https://www.nomadproject.io/docs/http/job.html
 
             arguments:
               - id
+              - index  :(dict) optional, provides a dictionary for keeping track of x-nomad-index
             returns: dict
             raises:
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self.request(id, "summary", method="get").json()
+        return self.request(id, "summary", method="get", link=link).json()
 
     def register_job(self, id, job):
         """ Registers a new job or updates an existing job

--- a/nomad/api/jobs.py
+++ b/nomad/api/jobs.py
@@ -63,7 +63,7 @@ class Jobs(Requester):
         jobs = self.get_jobs()
         return iter(jobs)
 
-    def get_jobs(self, prefix=None, link=None):
+    def get_jobs(self, prefix=None, index=None):
         """ Lists all the jobs registered with Nomad.
 
            https://www.nomadproject.io/docs/http/jobs.html
@@ -77,7 +77,7 @@ class Jobs(Requester):
               - nomad.api.exceptions.URLNotFoundNomadException
         """
         params = {"prefix": prefix}
-        return self.request(method="get", params=params, link=link).json()
+        return self.request(method="get", params=params, index=index).json()
 
     def register_job(self, job):
         """ Register a job with Nomad.

--- a/nomad/api/jobs.py
+++ b/nomad/api/jobs.py
@@ -63,20 +63,21 @@ class Jobs(Requester):
         jobs = self.get_jobs()
         return iter(jobs)
 
-    def get_jobs(self, prefix=None):
+    def get_jobs(self, prefix=None, link=None):
         """ Lists all the jobs registered with Nomad.
 
            https://www.nomadproject.io/docs/http/jobs.html
             arguments:
               - prefix :(str) optional, specifies a string to filter jobs on based on an prefix.
                         This is specified as a querystring parameter.
+              - index  :(dict) optional, provides a dictionary for keeping track of x-nomad-index
             returns: list
             raises:
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
         params = {"prefix": prefix}
-        return self.request(method="get", params=params).json()
+        return self.request(method="get", params=params, link=link).json()
 
     def register_job(self, job):
         """ Register a job with Nomad.

--- a/nomad/api/namespace.py
+++ b/nomad/api/namespace.py
@@ -48,19 +48,20 @@ class Namespace(Requester):
         except nomad.api.exceptions.URLNotFoundNomadException:
             raise KeyError
 
-    def get_namespace(self, id):
+    def get_namespace(self, id, index=None):
         """ Query a single namespace.
 
            https://www.nomadproject.io/api/namespaces.html
 
             arguments:
               - id
+              - index  :(dict) optional, provides a dictionary for keeping track of x-nomad-index
             returns: dict
             raises:
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self.request(id, method="get").json()
+        return self.request(id, method="get", index=index).json()
 
     def create_namespace(self, namespace):
         """ create namespace

--- a/nomad/api/namespaces.py
+++ b/nomad/api/namespaces.py
@@ -57,17 +57,18 @@ class Namespaces(Requester):
         namespaces = self.get_namespaces()
         return iter(namespaces)
 
-    def get_namespaces(self, prefix=None):
+    def get_namespaces(self, prefix=None, index=None):
         """ Lists all the namespaces registered with Nomad.
 
            https://www.nomadproject.io/docs/enterprise/namespaces/index.html
             arguments:
               - prefix :(str) optional, specifies a string to filter namespaces on based on an prefix.
                         This is specified as a querystring parameter.
+              - index  :(dict) optional, provides a dictionary for keeping track of x-nomad-index
             returns: list
             raises:
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
         params = {"prefix": prefix}
-        return self.request(method="get", params=params).json()
+        return self.request(method="get", params=params, index=index).json()

--- a/nomad/api/node.py
+++ b/nomad/api/node.py
@@ -48,29 +48,35 @@ class Node(Requester):
         except nomad.api.exceptions.URLNotFoundNomadException:
             raise KeyError
 
-    def get_node(self, id):
+    def get_node(self, id, index=None):
         """ Query the status of a client node registered with Nomad.
 
            https://www.nomadproject.io/docs/http/node.html
+
+            arguments:
+              - index  :(dict) optional, provides a dictionary for keeping track of x-nomad-index
 
             returns: dict
             raises:
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self.request(id, method="get").json()
+        return self.request(id, method="get", index=index).json()
 
-    def get_allocations(self, id):
+    def get_allocations(self, id, index=None):
         """ Query the allocations belonging to a single node.
 
            https://www.nomadproject.io/docs/http/node.html
+
+            arguments:
+              - index  :(dict) optional, provides a dictionary for keeping track of x-nomad-index
 
             returns: list
             raises:
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self.request(id, "allocations", method="get").json()
+        return self.request(id, "allocations", method="get", index=index).json()
 
     def evaluate_node(self, id):
         """ Creates a new evaluation for the given node.

--- a/nomad/api/nodes.py
+++ b/nomad/api/nodes.py
@@ -61,17 +61,18 @@ class Nodes(Requester):
         nodes = self.get_nodes()
         return iter(nodes)
 
-    def get_nodes(self, prefix=None):
+    def get_nodes(self, prefix=None, index=None):
         """ Lists all the client nodes registered with Nomad.
 
            https://www.nomadproject.io/docs/http/nodes.html
             arguments:
               - prefix :(str) optional, specifies a string to filter nodes on based on an prefix.
                         This is specified as a querystring parameter.
+              - index  :(dict) optional, provides a dictionary for keeping track of x-nomad-index
             returns: list
             raises:
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
         params = {"prefix": prefix}
-        return self.request(method="get", params=params).json()
+        return self.request(method="get", params=params, index=index).json()

--- a/nomad/api/sentinel.py
+++ b/nomad/api/sentinel.py
@@ -23,7 +23,7 @@ class Sentinel(Requester):
     def __getattr__(self, item):
         raise AttributeError
 
-    def get_policies(self):
+    def get_policies(self, index=None):
         """ Get a list of policies.
 
             https://www.nomadproject.io/api/sentinel-policies.html
@@ -51,10 +51,13 @@ class Sentinel(Requester):
         """
         return self.request("policy", id, json=policy, method="post")
 
-    def get_policy(self, id):
+    def get_policy(self, id, index=None):
         """ Get a spacific policy.
 
             https://www.nomadproject.io/api/sentinel-policies.html
+
+            arguments:
+              - index  :(dict) optional, provides a dictionary for keeping track of x-nomad-index
 
             returns: dict
 
@@ -62,7 +65,7 @@ class Sentinel(Requester):
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-        return self.request("policy", id, method="get").json()
+        return self.request("policy", id, method="get", index=index).json()
 
     def update_policy(self, id, policy):
         """ Create policy.


### PR DESCRIPTION
I've tried to implement this in a backwards compatible way, without adjusting the return value from API calls, so using a dictionary to essentially pass the index parameter by reference rather than value making it possible to update.

Interested in your thoughts on it.