### PR TITLE
support NOMAD_CLIENT_CERT and NOMAD_CLIENT_KEY

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,14 +48,16 @@ n.job.deregister_job(j)
 
 ## Environment Variables
 
-This library also supports environment variables: `NOMAD_ADDR`, `NOMAD_NAMESPACE`, `NOMAD_TOKEN`, `NOMAD_REGION` for ease of configuration
-and unifying with nomad cli tools and other libraries.
+This library also supports environment variables: `NOMAD_ADDR`, `NOMAD_NAMESPACE`, `NOMAD_TOKEN`, `NOMAD_REGION`, `NOMAD_CLIENT_CERT`, and `NOMAD_CLIENT_KEY`
+for ease of configuration and unifying with nomad cli tools and other libraries.
 
 ```bash
 NOMAD_ADDR=http://127.0.0.1:4646
 NOMAD_NAMESPACE=default
 NOMAD_TOKEN=xxxx-xxxx-xxxx-xxxx
 NOMAD_REGION=us-east-1a
+NOMAD_CLIENT_CERT=/path/to/tls/client.crt
+NOMAD_CLIENT_KEY=/path/to/tls/client.key
 ```
 
 ## Class Dunders

--- a/nomad/__init__.py
+++ b/nomad/__init__.py
@@ -4,18 +4,19 @@ import os
 
 class Nomad(object):
 
-    def __init__(self, 
-        host='127.0.0.1', 
-        secure=False, 
+    def __init__(self,
+        host='127.0.0.1',
+        secure=False,
         port=4646,
         address=os.getenv('NOMAD_ADDR', None),
         namespace=os.getenv('NOMAD_NAMESPACE', None),
-        token=os.getenv('NOMAD_TOKEN', None), 
-        timeout=5, 
-        region=os.getenv('NOMAD_REGION', None), 
-        version='v1', 
-        verify=False, 
-        cert=()):
+        token=os.getenv('NOMAD_TOKEN', None),
+        timeout=5,
+        region=os.getenv('NOMAD_REGION', None),
+        version='v1',
+        verify=False,
+        cert=(os.getenv('NOMAD_CLIENT_CERT', None),
+              os.getenv('NOMAD_CLIENT_KEY', None))):
         """ Nomad api client
 
           https://github.com/jrxFive/python-nomad/
@@ -51,7 +52,7 @@ class Nomad(object):
         self.version = version
         self.token = token
         self.verify = verify
-        self.cert = cert
+        self.cert = cert if all(cert) else ()
         self.__namespace = namespace
 
         self.requester_settings = {


### PR DESCRIPTION
https://nomadproject.io/guides/security/securing-nomad.html

When using Nomad in a secured fashion, allow the user to specify
environment variables NOMAD_CLIENT_CERT and NOMAD_CLIENT_KEY to
specify custom a cert and key.

This behavior matches that of the official Nomad cli.