### PR TITLE
Exception not requests.Response with BaseNomadException str dunder

### DIFF
--- a/nomad/api/exceptions.py
+++ b/nomad/api/exceptions.py
@@ -1,10 +1,16 @@
+import requests
+
+
 class BaseNomadException(Exception):
     """General Error occurred when interacting with nomad API"""
     def __init__(self, nomad_resp):
         self.nomad_resp = nomad_resp
 
     def __str__(self):
-        return 'The {0} was raised with following response: {1}.'.format(self.__class__.__name__, self.nomad_resp.text)
+        if isinstance(self.nomad_resp, requests.Response) and hasattr(self.nomad_resp, "text"):
+            return 'The {0} was raised with following response: {1}.'.format(self.__class__.__name__, self.nomad_resp.text)
+        else:
+            return 'The {0} was raised due to the following error: {1}'.format(self.__class__.__name__,  str(self.nomad_resp))
 
 
 class URLNotFoundNomadException(BaseNomadException):

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -46,6 +46,13 @@ def test_base_delete_connection_error():
         j = n.job.deregister_job("example")
 
 
+def test_base_raise_exception_():
+    n = nomad.Nomad(
+        host="162.16.10.102", port=common.NOMAD_PORT, timeout=0.001, verify=False)
+    with pytest.raises(nomad.api.exceptions.BaseNomadException):
+        j = n.job.deregister_job("example")
+
+
 @pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 7, 0), reason="Nomad dispatch not supported")
 def test_base_get_connnection_not_authorized():
     n = nomad.Nomad(

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,8 +1,12 @@
-import pytest
-import tests.common as common
-import nomad
 import os
+
+import mock
+import pytest
+import requests
 import responses
+
+import nomad
+import tests.common as common
 
 
 def test_base_region_qs():
@@ -46,11 +50,33 @@ def test_base_delete_connection_error():
         j = n.job.deregister_job("example")
 
 
-def test_base_raise_exception_():
-    n = nomad.Nomad(
-        host="162.16.10.102", port=common.NOMAD_PORT, timeout=0.001, verify=False)
-    with pytest.raises(nomad.api.exceptions.BaseNomadException):
-        j = n.job.deregister_job("example")
+@mock.patch("nomad.api.base.requests.Session")
+def test_base_raise_exception_not_requests_response_object(mock_requests):
+    mock_requests().delete.side_effect = [requests.RequestException()]
+
+    try:
+        n = nomad.Nomad(
+            host="162.16.10.102",
+            port=common.NOMAD_PORT,
+            timeout=0.001,
+            verify=False
+        )
+
+        _ = n.job.deregister_job("example")
+
+    except nomad.api.exceptions.BaseNomadException as err:
+        assert hasattr(err, "text") is False
+        assert isinstance(err.nomad_resp, requests.RequestException)
+        assert "raised due" in str(err)
+
+
+def test_base_raise_exception_is_requests_response_object(nomad_setup):
+    try:
+        _ = nomad_setup.job.deregister_job("example")
+    except nomad.api.exceptions.BaseNomadException as err:
+        assert hasattr(err, "text") is True
+        assert isinstance(err.nomad_resp, requests.Response)
+        assert "raised with" in str(err)
 
 
 @pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 7, 0), reason="Nomad dispatch not supported")

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -54,7 +54,7 @@ def test_base_delete_connection_error():
 def test_base_raise_exception_not_requests_response_object(mock_requests):
     mock_requests().delete.side_effect = [requests.RequestException()]
 
-    try:
+    with pytest.raises(nomad.api.exceptions.BaseNomadException) as excinfo:
         n = nomad.Nomad(
             host="162.16.10.102",
             port=common.NOMAD_PORT,
@@ -64,19 +64,24 @@ def test_base_raise_exception_not_requests_response_object(mock_requests):
 
         _ = n.job.deregister_job("example")
 
-    except nomad.api.exceptions.BaseNomadException as err:
-        assert hasattr(err, "text") is False
-        assert isinstance(err.nomad_resp, requests.RequestException)
-        assert "raised due" in str(err)
+    # excinfo is a ExceptionInfo instance, which is a wrapper around the actual exception raised.
+    # The main attributes of interest are .type, .value and .traceback.
+    # https://docs.pytest.org/en/3.0.1/assert.html#assertions-about-expected-exceptions
+    assert hasattr(excinfo.value.nomad_resp, "text") is False
+    assert isinstance(excinfo.value.nomad_resp, requests.RequestException)
+    assert "raised due" in str(excinfo)
 
 
 def test_base_raise_exception_is_requests_response_object(nomad_setup):
-    try:
-        _ = nomad_setup.job.deregister_job("example")
-    except nomad.api.exceptions.BaseNomadException as err:
-        assert hasattr(err, "text") is True
-        assert isinstance(err.nomad_resp, requests.Response)
-        assert "raised with" in str(err)
+    with pytest.raises(nomad.api.exceptions.BaseNomadException) as excinfo:
+        _ = nomad_setup.job.get_job("examplezz")
+
+    # excinfo is a ExceptionInfo instance, which is a wrapper around the actual exception raised.
+    # The main attributes of interest are .type, .value and .traceback.
+    # https://docs.pytest.org/en/3.0.1/assert.html#assertions-about-expected-exceptions
+    assert hasattr(excinfo.value.nomad_resp, "text") is True
+    assert isinstance(excinfo.value.nomad_resp, requests.Response)
+    assert "raised with" in str(excinfo)
 
 
 @pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 7, 0), reason="Nomad dispatch not supported")


### PR DESCRIPTION
Addressing #107, add safety checks to verify that the passed parameter of `nomad_resp` is a `requests.Response` object if it is not cast str around exception with different message. 

Not a huge fan of have a conditional __str__  with different messages (along with checking for certain substrings as a test) but this should at least fix the bug and ensure somewhat backwards compatibility. Technically `text` in requests.Response is not a guarantee either since its kwargs are popped for response and request and can possibly be `None`.

If we do eventually move to python 3+ only support adding annotations should help a bunch when visually inspecting or even mypy level runtime checking.