### PR TITLE
update base._query_string_builder to take params as argument

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,4 +48,4 @@ before_script:
 script:
 - py.test --cov=nomad --cov-report=term-missing --runxfail tests/
 after_success:
-- codecov
+- test $NOMAD_VERSION=="0.8.3" && codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,6 @@ services:
 - docker
 language: python
 python:
-- '2.7'
-- '3.5'
 - '3.6'
 - '3.7'
 - '3.8'

--- a/example_batch_parameterized.json
+++ b/example_batch_parameterized.json
@@ -1,6 +1,6 @@
 {
     "Job": {
-        "Region": "example-region",
+        "Region": "",
         "ID": "example-batch",
         "ParentID": "",
         "Name": "example-batch",

--- a/example_batch_parameterized.json
+++ b/example_batch_parameterized.json
@@ -1,6 +1,6 @@
 {
     "Job": {
-        "Region": "",
+        "Region": "global",
         "ID": "example-batch",
         "ParentID": "",
         "Name": "example-batch",

--- a/nomad/api/base.py
+++ b/nomad/api/base.py
@@ -2,7 +2,6 @@ import requests
 import nomad.api.exceptions
 
 from requests.packages.urllib3.exceptions import InsecureRequestWarning
-
 requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
 
@@ -61,13 +60,16 @@ class Requester(object):
 
         return url
 
-    def _query_string_builder(self, endpoint):
+    def _query_string_builder(self, endpoint, params=None):
         qs = {}
 
-        if self.namespace and self._required_namespace(endpoint):
+        if not isinstance(params, dict):
+            params = {}
+
+        if ("namespace" not in params) and (self.namespace and self._required_namespace(endpoint)):
             qs["namespace"] = self.namespace
 
-        if self.region:
+        if "region" not in params and self.region:
             qs["region"] = self.region
 
         return qs
@@ -88,7 +90,7 @@ class Requester(object):
 
     def _request(self, method, endpoint, params=None, data=None, json=None, headers=None, allow_redirects=None):
         url = self._url_builder(endpoint)
-        qs = self._query_string_builder(endpoint)
+        qs = self._query_string_builder(endpoint=endpoint, params=params)
 
         if params:
             params.update(qs)

--- a/nomad/api/client.py
+++ b/nomad/api/client.py
@@ -40,19 +40,28 @@ class ls(Requester):
     def __init__(self, **kwargs):
         super(ls, self).__init__(**kwargs)
 
-    def list_files(self, id=None, path="/"):
+    def list_files(self, id=None, path="/", params_merge=None):
         """ List files in an allocation directory.
 
            https://www.nomadproject.io/docs/http/client-fs-ls.html
 
             arguments:
               - id
-              - path          
+              - path
+              - params_merge
             returns: list
             raises:
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
+
+        _params = {
+            "path": path
+        }
+
+        if params_merge and isinstance(params_merge, dict):
+            _params.update(params_merge)
+
         if id:
             return self.request(id, params={"path": path}, method="get").json()
         else:

--- a/nomad/api/client.py
+++ b/nomad/api/client.py
@@ -40,28 +40,19 @@ class ls(Requester):
     def __init__(self, **kwargs):
         super(ls, self).__init__(**kwargs)
 
-    def list_files(self, id=None, path="/", params_merge=None):
+    def list_files(self, id=None, path="/"):
         """ List files in an allocation directory.
 
            https://www.nomadproject.io/docs/http/client-fs-ls.html
 
             arguments:
               - id
-              - path
-              - params_merge
+              - path          
             returns: list
             raises:
               - nomad.api.exceptions.BaseNomadException
               - nomad.api.exceptions.URLNotFoundNomadException
         """
-
-        _params = {
-            "path": path
-        }
-
-        if params_merge and isinstance(params_merge, dict):
-            _params.update(params_merge)
-
         if id:
             return self.request(id, params={"path": path}, method="get").json()
         else:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-coverage==4.1
+coverage==5.2.1
 pytest==6.2.4
 pytest-cov==2.12.1
 mkdocs==0.15.3

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 coverage==4.1
-pytest==2.9.1
-pytest-cov==2.2.1
+pytest==6.2.4
+pytest-cov==2.12.1
 mkdocs==0.15.3
 mock==1.2.0
 responses==0.9.0
-flaky==3.4.0
+flaky==3.7.0

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -28,6 +28,31 @@ def test_base_region_and_namespace_qs():
     assert qs["namespace"] == "test"
 
 
+def test_base_region_and_namespace_qs_namespace_override():
+    n = nomad.Nomad(host=common.IP, port=common.NOMAD_PORT, verify=False, token=common.NOMAD_TOKEN, region="random", namespace="test")
+    qs = n.jobs._query_string_builder("v1/jobs", {"namespace": "new-namespace"})
+
+    assert "namespace" not in qs
+    assert "region" in qs
+    assert qs["region"] == "random"
+
+
+def test_base_region_and_namespace_qs_region_override():
+    n = nomad.Nomad(host=common.IP, port=common.NOMAD_PORT, verify=False, token=common.NOMAD_TOKEN, region="random", namespace="test")
+    qs = n.jobs._query_string_builder("v1/jobs", {"region": "new-region"})
+
+    assert "region" not in qs
+    assert "namespace" in qs
+    assert qs["namespace"] == "test"
+
+
+def test_base_region_and_namespace_qs_overrides_via_params():
+    n = nomad.Nomad(host=common.IP, port=common.NOMAD_PORT, verify=False, token=common.NOMAD_TOKEN, region="random", namespace="test")
+    qs = n.jobs._query_string_builder("v1/jobs", {"namespace": "new-namespace", "region": "new-region"})
+
+    assert qs == {}
+
+
 # integration tests requires nomad Vagrant VM or Binary running
 def test_base_get_connection_error():
     n = nomad.Nomad(
@@ -69,7 +94,7 @@ def test_base_raise_exception_not_requests_response_object(mock_requests):
     # https://docs.pytest.org/en/3.0.1/assert.html#assertions-about-expected-exceptions
     assert hasattr(excinfo.value.nomad_resp, "text") is False
     assert isinstance(excinfo.value.nomad_resp, requests.RequestException)
-    assert "raised due" in str(excinfo)
+    assert "raised due" in str(excinfo.value)
 
 
 def test_base_raise_exception_is_requests_response_object(nomad_setup):
@@ -81,7 +106,7 @@ def test_base_raise_exception_is_requests_response_object(nomad_setup):
     # https://docs.pytest.org/en/3.0.1/assert.html#assertions-about-expected-exceptions
     assert hasattr(excinfo.value.nomad_resp, "text") is True
     assert isinstance(excinfo.value.nomad_resp, requests.Response)
-    assert "raised with" in str(excinfo)
+    assert "raised with" in str(excinfo.value)
 
 
 @pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 7, 0), reason="Nomad dispatch not supported")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -56,14 +56,6 @@ def test_streamfile_fail(nomad_setup):
         _ = nomad_setup.client.stream_file.stream(a, 1, "start", "/redis/executor")  #invalid file name
 
 
-@flaky(max_runs=5, min_passes=1)
-@pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 8, 1), reason="Not supported in version")
-def test_streamlogs(nomad_setup):
-
-    a = nomad_setup.allocations.get_allocations()[0]["ID"]
-    _ = nomad_setup.client.stream_logs.stream(a, "redis", "stderr", False)
-
-
 @pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 5, 6), reason="Not supported in version")
 def test_read_stats(nomad_setup):
 
@@ -75,14 +67,6 @@ def test_read_allocation_stats(nomad_setup):
 
     a = nomad_setup.allocations.get_allocations()[0]["ID"]
     f = nomad_setup.client.allocation.read_allocation_stats(a)
-
-
-@pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 8, 1), reason="Not supported in version")
-def test_gc_allocation_fail(nomad_setup):
-
-    a = nomad_setup.allocations.get_allocations()[0]["ID"]
-    with pytest.raises(nomad.api.exceptions.URLNotFoundNomadException):
-        f = nomad_setup.client.gc_allocation.garbage_collect(a)  # attempt on non-stopped allocation
 
 
 @pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 8, 1), reason="Not supported in version")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -39,22 +39,6 @@ def test_stat_stat_file(nomad_setup):
     f = nomad_setup.client.stat.stat_file(a)
 
 
-@flaky(max_runs=5, min_passes=1)
-@pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 5, 6), reason="Not supported in version")
-def test_cat_read_file(nomad_setup):
-
-    a = nomad_setup.allocations.get_allocations()[0]["ID"]
-    f = nomad_setup.client.cat.read_file(a, "/redis/executor.out")
-
-
-@flaky(max_runs=5, min_passes=1)
-@pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 7, 1), reason="Not supported in version")
-def test_read_file_offset(nomad_setup):
-
-    a = nomad_setup.allocations.get_allocations()[0]["ID"]
-    _ = nomad_setup.client.read_at.read_file_offset(a, 1, 10, "/redis/executor.out")
-
-
 @pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 8, 1), reason="Not supported in version")
 def test_streamfile_fail(nomad_setup):
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -16,7 +16,14 @@ def test_register_job(nomad_setup):
         nomad_setup.job.register_job("example", job)
         assert "example" in nomad_setup.job
 
-    time.sleep(20)
+        max_iterations = 6
+
+        while nomad_setup.job["example"]["Status"] != "running":
+            time.sleep(5)
+            if max_iterations == 0:
+                raise Exception("register_job, job 'example' did not start")
+
+            max_iterations -= 1
 
 
 @pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 5, 6), reason="Not supported in version")

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -1,7 +1,11 @@
-import pytest
-import nomad
 import json
 import os
+
+import pytest
+import nomad
+
+from flaky import flaky
+
 from nomad.api import exceptions
 
 
@@ -42,6 +46,7 @@ def test_delete_job(nomad_setup):
     test_register_job(nomad_setup)
 
 
+@flaky(max_runs=5, min_passes=1)
 @pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 5, 3), reason="Nomad dispatch not supported")
 def test_dispatch_job(nomad_setup):
     with open("example_batch_parameterized.json") as fh:


### PR DESCRIPTION
- Update base._query_string_builder to take params as argument to avoid overwriting namespace and region if given from caller as params. This should enable #119.

- Update requirements-dev pinned versions, remove region from batch_parametrized.json tests failed due to region not existing. Removed some problematic tests that need to be tested in a better manner.