### PR TITLE
Support scaling-related operations

### DIFF
--- a/nomad/api/job.py
+++ b/nomad/api/job.py
@@ -153,6 +153,20 @@ class Job(Requester):
         """
         return self.request(id, "summary", method="get").json()
 
+    def get_scale_status(self, id):
+        """ This endpoint reads scale information about a job.
+
+           https://www.nomadproject.io/docs/http/job.html
+
+            arguments:
+              - id
+            returns: dict
+            raises:
+              - nomad.api.exceptions.BaseNomadException
+              - nomad.api.exceptions.URLNotFoundNomadException
+        """
+        return self.request(id, "scale", method="get").json()
+
     def register_job(self, id, job):
         """ Registers a new job or updates an existing job
 
@@ -299,6 +313,79 @@ class Job(Requester):
         if purge is not None:
             if not isinstance(purge, bool):
                 raise nomad.api.exceptions.InvalidParameters("purge is invalid "
-                        "(expected type %s but got %s)"%(type(bool()), type(purge)))
+                        "(expected type %s but got %s)"%(bool, type(purge)))
             params = {"purge": purge}
         return self.request(id, params=params, method="delete").json()
+
+    def scale_job(
+            self,
+            id,
+            target,
+            count=None,
+            message=None,
+            error=None,
+            meta=None,
+            policy_override=None):
+        """ This endpoint performs a scaling action against a job. Currently, this
+            endpoint supports scaling the count for a task group. This will raise
+            a `BadRequestNomadException` if the job has an active deployment.
+
+           https://www.nomadproject.io/docs/http/job.html
+
+            arguments:
+              - id
+              - target (dict), Specifies the target of the scaling operation.
+                Must contain a field `Group` with the name of the task group that
+                is the target of this scaling action
+              - count (int), Optional, specifies the new task group count
+              - message (str), Optional, description of the scale action,
+                persisted as part of the scaling event. Indicates information or
+                reason for scaling.
+              - error (str), Optional, description of the scale action, persisted
+                as part of the scaling event. Indicates an error state preventing
+                scaling.
+              - meta (any JSON-serializable value), JSON block that is persisted
+                as part of the scaling event
+              - policy_override (bool), Optional. If set, any soft mandatory
+                Sentinel policies will be overridden. This allows a job to be
+                scaled when it would be denied by policy. Default: False.
+
+            returns: dict
+            raises:
+              - nomad.api.exceptions.BaseNomadException
+              - nomad.api.exceptions.URLNotFoundNomadException
+              - nomad.api.exceptions.InvalidParameters
+        """
+        scale_json = {
+            "Target": target
+        }
+
+        if count is not None:
+            if not isinstance(count, int):
+                raise nomad.api.exceptions.InvalidParameters("count is invalid "
+                        "(expected type %s but got %s)"%(int, type(count)))
+            scale_json["Count"] = count
+
+        if message is not None:
+            if not isinstance(message, str):
+                raise nomad.api.exceptions.InvalidParameters("message is invalid "
+                        "(expected type %s but got %s)"%(str, type(message)))
+            scale_json["Message"] = str(message)
+
+        if error is not None:
+            if not isinstance(error, str):
+                raise nomad.api.exceptions.InvalidParameters("error is invalid "
+                        "(expected type %s but got %s)"%(str, type(error)))
+            scale_json["Error"] = str(error)
+
+        if meta is not None:
+            scale_json["Meta"] = meta
+
+        if policy_override is not None:
+            if not isinstance(policy_override, bool):
+                raise nomad.api.exceptions.InvalidParameters(
+                    ("policy_override is invalid (expected type %s but got"
+                    " %s)") % (bool, type(policy_override)))
+            scale_json["PolicyOverride"] = policy_override
+
+        return self.request(id, json=scale_json, method="post").json()

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -149,15 +149,20 @@ def test_revert_job(nomad_setup):
     nomad_setup.job.revert_job("example", prior_job_version, current_job_version)
 
 @pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 6, 0), reason="Not supported in version")
-def test_revert_job(nomad_setup):
-    current_job_version = nomad_setup.job.get_deployment("example")["JobVersion"]
-    prior_job_version = current_job_version - 1
-    nomad_setup.job.revert_job("example", prior_job_version, current_job_version)
-
-@pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 6, 0), reason="Not supported in version")
 def test_stable_job(nomad_setup):
     current_job_version = nomad_setup.job.get_deployment("example")["JobVersion"]
     nomad_setup.job.stable_job("example", current_job_version, True)
+
+@pytest.mark.skipif(tuple(int(i) for i in os.environ.get("NOMAD_VERSION").split(".")) < (0, 12, 0), reason="Not supported in version")
+def test_scale_job(nomad_setup):
+    scale_response = nomad_setup.job.scale_job(
+        "example",
+        target={ "Group": "example-task-group" },
+        count=1,
+        message="test",
+        meta={ "answer": 42 }
+    )
+    assert "EvalID" in scale_response
 
 
 def test_dunder_getitem_exist(nomad_setup):


### PR DESCRIPTION
This adds two endpoints that are new since 0.12.0.
(also removes duplicated test `test_revert_job`)

The API contract of the `/:job_id/scale` endpoint is not fully clear to me yet (see [this issue](https://github.com/hashicorp/nomad/issues/13056)) so this might need further updates.