### PR TITLE
Add namespace agrs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['2.7', '3.7']
+        python-version: ['2.7', '3.7', '3.10']
         nomad-version: ['1.0.0', '1.1.4']
 
     steps:

--- a/nomad/api/allocations.py
+++ b/nomad/api/allocations.py
@@ -32,12 +32,14 @@ class Allocations(Requester):
         response = self.get_allocations()
         return iter(response)
 
-    def get_allocations(self, prefix=None):
+    def get_allocations(self, prefix=None, namespace=None):
         """ Lists all the allocations.
 
            https://www.nomadproject.io/docs/http/allocs.html
             arguments:
               - prefix :(str) optional, specifies a string to filter allocations on based on an prefix.
+                        This is specified as a querystring parameter.
+              - namespace :(str) optional, specifies the target namespace. Specifying * would return all jobs.
                         This is specified as a querystring parameter.
             returns: list
             raises:
@@ -45,4 +47,7 @@ class Allocations(Requester):
               - nomad.api.exceptions.URLNotFoundNomadException
         """
         params = {"prefix": prefix}
+        if namespace:
+            params["namespace"] = namespace
+
         return self.request(method="get", params=params).json()

--- a/nomad/api/deployments.py
+++ b/nomad/api/deployments.py
@@ -56,13 +56,15 @@ class Deployments(Requester):
         except nomad.api.exceptions.URLNotFoundNomadException:
             raise KeyError
 
-    def get_deployments(self, prefix=""):
+    def get_deployments(self, prefix="", namespace=None):
         """ This endpoint lists all deployments.
 
            https://www.nomadproject.io/docs/http/deployments.html
 
             optional_arguments:
               - prefix, (default "") Specifies a string to filter deployments on based on an index prefix.
+                        This is specified as a querystring parameter.
+              - namespace :(str) optional, specifies the target namespace. Specifying * would return all jobs.
                         This is specified as a querystring parameter.
 
             returns: list of dicts
@@ -71,4 +73,7 @@ class Deployments(Requester):
               - nomad.api.exceptions.URLNotFoundNomadException
         """
         params = {"prefix": prefix}
+        if namespace:
+            params["namespace"] = namespace
+
         return self.request(params=params, method="get").json()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-requests==2.28.1
+requests==2.27.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-requests==2.26.0
+requests==2.28.1

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@ setuptools.setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,8 @@ setuptools.setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
     ],
     keywords='nomad hashicorp client',
 )


### PR DESCRIPTION
1. Added support for namespace arguments for deployment and allocations endpoints.
2. Added support for Python 3.10.
3. Upgrade `requests` library (support 3.10 Python). This version also doesn't support Python 3.5. The latest version of lib doesn't support even 2.7/3.6 and I'm not sure about your plans for support these versions.