### PR TITLE
add scaling policy endpoint

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
     env:
       NOMAD_IP: '127.0.0.1'
       NOMAD_PORT: '4646'
-      NOMAD_LATEST: '1.1.4'
+      NOMAD_LATEST: '1.1.18'
 
     strategy:
       fail-fast: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['2.7', '3.7']
-        nomad-version: ['1.0.0', '1.1.4']
+        nomad-version: ['1.0.0', '1.1.18']
 
     steps:
     - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 .vagrant
 .build
 .venv
+
+example.json
+example.nomad

--- a/nomad/__init__.py
+++ b/nomad/__init__.py
@@ -87,6 +87,7 @@ class Nomad(object):
         self._nodes = api.Nodes(**self.requester_settings)
         self._operator = api.Operator(**self.requester_settings)
         self._regions = api.Regions(**self.requester_settings)
+        self._scaling = api.Scaling(**self.requester_settings)
         self._sentinel = api.Sentinel(**self.requester_settings)
         self._status = api.Status(**self.requester_settings)
         self._system = api.System(**self.requester_settings)
@@ -160,6 +161,10 @@ class Nomad(object):
     @property
     def regions(self):
         return self._regions
+
+    @property
+    def scaling(self):
+        return self._scaling
 
     @property
     def status(self):

--- a/nomad/api/__init__.py
+++ b/nomad/api/__init__.py
@@ -19,6 +19,7 @@ from nomad.api.node import Node
 from nomad.api.nodes import Nodes
 from nomad.api.operator import Operator
 from nomad.api.regions import Regions
+from nomad.api.scaling import Scaling
 from nomad.api.sentinel import Sentinel
 from nomad.api.status import Status
 from nomad.api.system import System

--- a/nomad/api/scaling.py
+++ b/nomad/api/scaling.py
@@ -1,0 +1,68 @@
+import nomad.api.exceptions
+
+from nomad.api.base import Requester
+
+
+class Scaling(Requester):
+    """
+    Endpoints are used to list and view scaling policies.
+
+    https://developer.hashicorp.com/nomad/api-docs/scaling-policies
+    """
+    ENDPOINT = "scaling"
+
+    def __init__(self, **kwargs):
+        super(Scaling, self).__init__(**kwargs)
+
+    def __str__(self):
+        return "{0}".format(self.__dict__)
+
+    def __repr__(self):
+        return "{0}".format(self.__dict__)
+
+    def __getattr__(self, item):
+        raise AttributeError
+
+    def get_scaling_policies(self, job="", type=""):
+        """
+        This endpoint returns the scaling policies from all jobs.
+
+        https://developer.hashicorp.com/nomad/api-docs/scaling-policies#list-scaling-policies
+
+        arguments:
+            - job
+            - type
+        returns: list of dicts
+        raises:
+            - nomad.api.exceptions.BaseNomadException
+            - nomad.api.exceptions.URLNotFoundNomadException
+        """
+        type_of_scaling_policies = [
+            "horizontal",
+            "vertical_mem",
+            "vertical_cpu",
+            "",
+        ] # we have only horizontal in OSS
+
+        if type not in type_of_scaling_policies:
+            raise nomad.api.exceptions.InvalidParameters("type is invalid "
+                "(expected values are {} but got {})".format(type_of_scaling_policies, type))
+
+        params = {"job": job, "type": type}
+
+        return self.request("policies", method="get", params=params).json()
+
+    def get_scaling_policy(self, id):
+        """
+        This endpoint reads a specific scaling policy.
+
+        https://developer.hashicorp.com/nomad/api-docs/scaling-policies#read-scaling-policy
+
+        arguments:
+            - id
+        returns: list of dicts
+        raises:
+            - nomad.api.exceptions.BaseNomadException
+            - nomad.api.exceptions.URLNotFoundNomadException
+        """
+        return self.request("policy/{}".format(id), method="get").json()

--- a/tests/test_scaling.py
+++ b/tests/test_scaling.py
@@ -1,0 +1,11 @@
+import pytest
+
+from nomad.api import exceptions
+
+def test_scaling_list(nomad_setup):
+    result = nomad_setup.scaling.get_scaling_policies()
+    assert not result
+
+def test_scaling_policy_not_exist(nomad_setup):
+    with pytest.raises(exceptions.URLNotFoundNomadException):
+        nomad_setup.scaling.get_scaling_policy("example")


### PR DESCRIPTION
I added `scaling-policies` endpoints:
https://developer.hashicorp.com/nomad/api-docs/scaling-policies#read-scaling-policy

I can add more tests, but we need merge PR with scaling related operations: https://github.com/jrxFive/python-nomad/pull/131
