### PR TITLE
fix ci and add CHANGELOG.me

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,8 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['2.7', '3.7', '3.10']
-        nomad-version: ['1.0.0', '1.1.18']
-
+        nomad-version: ['1.0.18', '1.1.18', '1.2.14', '1.3.7', '1.4.2']
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,9 +29,9 @@ jobs:
         nomad-version: ['1.0.0', '1.1.18']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Setup Nomad ${{ matrix.nomad-version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,14 +39,14 @@ jobs:
         NOMAD_VERSION: ${{ matrix.nomad-version }}
       shell: bash
       run: |
-       echo $NOMAD_VERSION
-       echo ${NOMAD_VERSION}
+        echo $NOMAD_VERSION
+        echo ${NOMAD_VERSION}
 
-       echo "downloading nomad"
-       curl -L -o /tmp/nomad_${NOMAD_VERSION}_linux_amd64.zip https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}_linux_amd64.zip
+        echo "downloading nomad"
+        curl -L -o /tmp/nomad_${NOMAD_VERSION}_linux_amd64.zip https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}_linux_amd64.zip
 
-       echo "unzip nomad"
-       unzip -d /tmp /tmp/nomad_${NOMAD_VERSION}_linux_amd64.zip
+        echo "unzip nomad"
+        unzip -d /tmp /tmp/nomad_${NOMAD_VERSION}_linux_amd64.zip
 
         echo "starting nomad server"
         /tmp/nomad agent -dev -bind ${NOMAD_IP} -node pynomad1 --acl-enabled > /dev/null 2>&1 &
@@ -58,9 +58,8 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-        if [ $PYTHON_VERSION = "2.7" ]
-          then
-            pip install -r requirements-dev-py27.txt
+        if [ $PYTHON_VERSION = "2.7" ] then
+          pip install -r requirements-dev-py27.txt
         else
           pip install -r requirements-dev.txt
         fi
@@ -82,13 +81,6 @@ jobs:
       run: |
         python -m pip install build
         python -m build --sdist --wheel
-    - name: Publish Test PyPi
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        user: __token__
-        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-        repository_url: https://test.pypi.org/legacy/
-        skip_existing: true
     - name: Publish/Release Package
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,7 +58,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-        if [ $PYTHON_VERSION = "2.7" ] then
+        if [ $PYTHON_VERSION = "2.7" ]; then
           pip install -r requirements-dev-py27.txt
         else
           pip install -r requirements-dev.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+## Unreleased
+* Add `namespace` agrument support for `get_allocations` and `get_deployments` endpoints (#133)
+* Add Python 3.10 support (#133)
+* Add support for pre-populated Sessions (#132)
+* Add scaling policy endpoint (#136)

--- a/requirements-dev-py27.txt
+++ b/requirements-dev-py27.txt
@@ -1,7 +1,7 @@
 coverage==5.2.1
 pytest==4.6.11
 pytest-cov==2.12.1
-mkdocs==1.2.3
+mkdocs==1.0.4
 mock==1.2.0
 flaky==3.7.0
 responses==0.13.4


### PR DESCRIPTION
* I added CHANGELOG.me
* I fixed CI: `mkdocs` doesn't support Python 2 anymore. The last supported version is `1.0.4`. My suggestion is: let's release 1.4.2 (with /search and /var endpoints) and after release 2.0.0 where we'll drop Python 2 support.
* I removed `Publish Test PyPi` step because it doesn't work a lot of time and we can fix it later. But right now we need to have green CI :)
* Added all nomad versions.