### PR TITLE
Remove support for Python 2 and upgrade deps

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,7 +81,6 @@ jobs:
         python -m pip install build
         python -m build --sdist --wheel
     - name: Publish/Release Package
-      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,13 +20,12 @@ jobs:
     env:
       NOMAD_IP: '127.0.0.1'
       NOMAD_PORT: '4646'
-      NOMAD_LATEST: '1.1.18'
 
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['2.7', '3.7', '3.10']
-        nomad-version: ['1.0.18', '1.1.18', '1.2.14', '1.3.7', '1.4.2']
+        python-version: ['3.7', '3.11'] # the oldest and newest support versions
+        nomad-version: ['1.0.18', '1.1.18', '1.2.15', '1.3.8', '1.4.3']
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
@@ -57,11 +56,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-        if [ $PYTHON_VERSION = "2.7" ]; then
-          pip install -r requirements-dev-py27.txt
-        else
-          pip install -r requirements-dev.txt
-        fi
+        pip install -r requirements-dev.txt
     - name: Before Tests
       shell: bash
       run: |
@@ -81,6 +76,7 @@ jobs:
         python -m pip install build
         python -m build --sdist --wheel
     - name: Publish/Release Package
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.0 (unreleased)
+* Up `requests` lib version to 2.28.1
+* Drop Python 2 and Python 3.6 support
+
 ## 1.5.0
 * Add `namespace` agrument support for `get_allocations` and `get_deployments` endpoints (#133)
 * Add Python 3.10 support (#133)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,5 +29,7 @@ pages:
    - Namespace: 'api/namespace.md'
    - Namespaces: 'api/namespaces.md'
    - Sentinel: 'api/sentinel.md'
+   - Variable: 'api/variable.md'
+   - Variables: 'api/variables.md'
    - Validate: 'api/validate.md'
 - Contributing: 'CONTRIBUTING.md'

--- a/requirements-dev-py27.txt
+++ b/requirements-dev-py27.txt
@@ -1,7 +1,0 @@
-coverage==5.2.1
-pytest==4.6.11
-pytest-cov==2.12.1
-mkdocs==1.0.4
-mock==1.2.0
-flaky==3.7.0
-responses==0.13.4

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
-coverage==5.2.1
-pytest==6.2.4
-pytest-cov==2.12.1
-mkdocs==1.2.3
-mock==1.2.0
+coverage==6.5.0
+pytest==7.2.0
+pytest-cov==4.0.0
+mkdocs==1.4.2
+mock==4.0.3
 flaky==3.7.0
-responses==0.13.4
+responses==0.22.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-requests==2.27.1
+requests==2.28.1

--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,6 @@ setuptools.setup(
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',


### PR DESCRIPTION
1. Remove support for an unsupported version of Python (Python 2, Python 3.6)
2. Upgrade dev deps.