### PR TITLE
Add missing parameters, do not pass None

### DIFF
--- a/nomad/api/allocations.py
+++ b/nomad/api/allocations.py
@@ -1,4 +1,6 @@
 """Nomad allocation: https://developer.hashicorp.com/nomad/api-docs/allocations"""
+from typing import Optional
+
 from nomad.api.base import Requester
 
 
@@ -10,6 +12,7 @@ class Allocations(Requester):
 
     https://www.nomadproject.io/docs/http/allocs.html
     """
+
     ENDPOINT = "allocations"
 
     def __init__(self, **kwargs):
@@ -32,22 +35,35 @@ class Allocations(Requester):
         response = self.get_allocations()
         return iter(response)
 
-    def get_allocations(self, prefix=None, namespace=None):
-        """ Lists all the allocations.
+    def get_allocations(  # pylint: disable=redefined-builtin,too-many-arguments
+        self,
+        prefix: Optional[str] = None,
+        filter: Optional[str] = None,
+        namespace: Optional[str] = None,
+        resources: Optional[bool] = None,
+        task_states: Optional[bool] = None,
+    ):
+        """Lists all the allocations.
 
-           https://www.nomadproject.io/docs/http/allocs.html
-            arguments:
-              - prefix :(str) optional, specifies a string to filter allocations on based on an prefix.
-                        This is specified as a querystring parameter.
-              - namespace :(str) optional, specifies the target namespace. Specifying * would return all jobs.
-                        This is specified as a querystring parameter.
-            returns: list
-            raises:
-              - nomad.api.exceptions.BaseNomadException
-              - nomad.api.exceptions.URLNotFoundNomadException
+        https://www.nomadproject.io/docs/http/allocs.html
+         arguments:
+           - prefix :(str) optional, specifies a string to filter allocations on based on an prefix.
+                     This is specified as a querystring parameter.
+           - filter :(str) optional
+           - namespace :(str) optional, specifies the target namespace. Specifying * would return all jobs.
+                     This is specified as a querystring parameter.
+           - resources :(bool) optional
+           - task_states :(bool) optional
+         returns: list
+         raises:
+           - nomad.api.exceptions.BaseNomadException
+           - nomad.api.exceptions.URLNotFoundNomadException
         """
-        params = {"prefix": prefix}
-        if namespace:
-            params["namespace"] = namespace
-
+        params = {
+            "prefix": prefix,
+            "filter": filter,
+            "namespace": namespace,
+            "resources": resources,
+            "task_states": task_states,
+        }
         return self.request(method="get", params=params).json()

--- a/nomad/api/allocations.py
+++ b/nomad/api/allocations.py
@@ -35,10 +35,10 @@ class Allocations(Requester):
         response = self.get_allocations()
         return iter(response)
 
-    def get_allocations(  # pylint: disable=redefined-builtin,too-many-arguments
+    def get_allocations(  # pylint: disable=too-many-arguments
         self,
         prefix: Optional[str] = None,
-        filter: Optional[str] = None,
+        filter_: Optional[str] = None,
         namespace: Optional[str] = None,
         resources: Optional[bool] = None,
         task_states: Optional[bool] = None,
@@ -49,7 +49,8 @@ class Allocations(Requester):
          arguments:
            - prefix :(str) optional, specifies a string to filter allocations on based on an prefix.
                      This is specified as a querystring parameter.
-           - filter :(str) optional
+           - filter_ :(str) optional
+                     Name has a trailing underscore not to conflict with builtin function.
            - namespace :(str) optional, specifies the target namespace. Specifying * would return all jobs.
                      This is specified as a querystring parameter.
            - resources :(bool) optional
@@ -61,7 +62,7 @@ class Allocations(Requester):
         """
         params = {
             "prefix": prefix,
-            "filter": filter,
+            "filter": filter_,
             "namespace": namespace,
             "resources": resources,
             "task_states": task_states,

--- a/nomad/api/base.py
+++ b/nomad/api/base.py
@@ -132,9 +132,9 @@ class Requester():  # pylint: disable=too-many-instance-attributes,too-few-publi
             params = query_string
 
         if self.token:
-            try:
+            if headers is not None:
                 headers["X-Nomad-Token"] = self.token
-            except TypeError:
+            else:
                 headers = {"X-Nomad-Token": self.token}
 
         response = None

--- a/nomad/api/base.py
+++ b/nomad/api/base.py
@@ -84,6 +84,9 @@ class Requester():  # pylint: disable=too-many-instance-attributes,too-few-publi
         if not isinstance(params, dict):
             params = {}
 
+        # Remove parameters that are None
+        params = {key: val for key, val in params.items() if val is not None}
+
         if ("namespace" not in params) and (self.namespace and self._required_namespace(endpoint)):
             query_string["namespace"] = self.namespace
 

--- a/nomad/api/jobs.py
+++ b/nomad/api/jobs.py
@@ -1,4 +1,5 @@
 """Nomad job: https://developer.hashicorp.com/nomad/api-docs/jobs"""
+from typing import Optional
 import nomad.api.exceptions
 
 from nomad.api.base import Requester
@@ -62,24 +63,35 @@ class Jobs(Requester):
         jobs = self.get_jobs()
         return iter(jobs)
 
-    def get_jobs(self, prefix=None, namespace=None):
-        """ Lists all the jobs registered with Nomad.
+    def get_jobs(  # pylint: disable=redefined-builtin
+        self,
+        prefix: Optional[str] = None,
+        namespace: Optional[str] = None,
+        filter: Optional[str] = None,
+        meta: Optional[bool] = None,
+    ):
+        """Lists all the jobs registered with Nomad.
 
-           https://www.nomadproject.io/docs/http/jobs.html
-            arguments:
-              - prefix :(str) optional, specifies a string to filter jobs on based on an prefix.
-                        This is specified as a querystring parameter.
-              - namespace :(str) optional, specifies the target namespace. Specifying * would return all jobs.
-                        This is specified as a querystring parameter.
-            returns: list
-            raises:
-              - nomad.api.exceptions.BaseNomadException
-              - nomad.api.exceptions.URLNotFoundNomadException
+        https://www.nomadproject.io/docs/http/jobs.html
+         arguments:
+           - prefix :(str) optional, specifies a string to filter jobs on based on an prefix.
+                     This is specified as a querystring parameter.
+           - namespace :(str) optional, specifies the target namespace. Specifying * would return all jobs.
+                     This is specified as a querystring parameter.
+           - filter :(str) optional, specifies the expression used to filter the result.
+           - meta :(bool) optional, if set, jobs returned will include a meta field containing
+                     key-value pairs provided in the job specification's meta block.
+         returns: list
+         raises:
+           - nomad.api.exceptions.BaseNomadException
+           - nomad.api.exceptions.URLNotFoundNomadException
         """
-        params = {"prefix": prefix}
-        if namespace:
-            params["namespace"] = namespace
-
+        params = {
+            "prefix": prefix,
+            "namespace": namespace,
+            "filter": filter,
+            "meta": meta,
+        }
         return self.request(method="get", params=params).json()
 
     def register_job(self, job):

--- a/nomad/api/jobs.py
+++ b/nomad/api/jobs.py
@@ -63,11 +63,11 @@ class Jobs(Requester):
         jobs = self.get_jobs()
         return iter(jobs)
 
-    def get_jobs(  # pylint: disable=redefined-builtin
+    def get_jobs(
         self,
         prefix: Optional[str] = None,
         namespace: Optional[str] = None,
-        filter: Optional[str] = None,
+        filter_: Optional[str] = None,
         meta: Optional[bool] = None,
     ):
         """Lists all the jobs registered with Nomad.
@@ -78,7 +78,8 @@ class Jobs(Requester):
                      This is specified as a querystring parameter.
            - namespace :(str) optional, specifies the target namespace. Specifying * would return all jobs.
                      This is specified as a querystring parameter.
-           - filter :(str) optional, specifies the expression used to filter the result.
+           - filter_ :(str) optional, specifies the expression used to filter the result.
+                     Name has a trailing underscore not to conflict with builtin function.
            - meta :(bool) optional, if set, jobs returned will include a meta field containing
                      key-value pairs provided in the job specification's meta block.
          returns: list
@@ -89,7 +90,7 @@ class Jobs(Requester):
         params = {
             "prefix": prefix,
             "namespace": namespace,
-            "filter": filter,
+            "filter": filter_,
             "meta": meta,
         }
         return self.request(method="get", params=params).json()


### PR DESCRIPTION
Add missing parameters to allocations.get_allocations and jobs.get_jobs.
Do not pass prefix if it's none (or any other param). This simplifies the code handling with optional parameters. If prefix is passed "", then allocations are sorted alphabetically, otherwise chronologically.