### PR TITLE
add release workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,8 +10,6 @@ on:
     branches: [ master ]
   registry_package:
     types: [published]
-  release:
-    types: [created, published, released]
   workflow_dispatch:
 
 jobs:
@@ -62,15 +60,4 @@ jobs:
       run: |
         ./run_tests.sh
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v2
-    - name: Create Package
-      shell: bash
-      run: |
-        python -m pip install build
-        python -m build --sdist --wheel
-    - name: Publish/Release Package
-      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}
+      uses: codecov/codecov-action@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,8 +4,6 @@ on:
   release:
     types:
       - created
-  pull_request:
-    branches: [ master ]
 
 jobs:
   publish:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,29 @@
+name: Publish
+
+on:
+  release:
+    types:
+      - created
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.11
+    - name: Install Dependencies
+      shell: bash
+      run: pip install build
+    - name: Create Package
+      shell: bash
+      run: python -m build --sdist --wheel
+    - name: Publish/Release Package
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
I moved the release workflow to a separate step, and instead of a tag trigger, I added a `release` trigger. We will publish a new version when we create a new release.