### PR TITLE
Only read env variables on __init__

### DIFF
--- a/nomad/__init__.py
+++ b/nomad/__init__.py
@@ -17,15 +17,15 @@ class Nomad:  # pylint: disable=too-many-public-methods,too-many-instance-attrib
         host: str = "127.0.0.1",
         secure: bool = False,
         port: int = 4646,
-        address: Optional[str] = os.getenv("NOMAD_ADDR", None),
+        address: Optional[str] = None,
         user_agent: Optional[str] = None,
-        namespace: Optional[str] = os.getenv("NOMAD_NAMESPACE", None),
-        token: Optional[str] = os.getenv("NOMAD_TOKEN", None),
+        namespace: Optional[str] = None,
+        token: Optional[str] = None,
         timeout: int = 5,
-        region: Optional[str] = os.getenv("NOMAD_REGION", None),
+        region: Optional[str] = None,
         version: str = "v1",
         verify: bool = False,
-        cert: tuple = (os.getenv("NOMAD_CLIENT_CERT", None), os.getenv("NOMAD_CLIENT_KEY", None)),
+        cert: tuple = (),
         session: requests.Session = None,
     ):
         """Nomad api client
@@ -57,19 +57,21 @@ class Nomad:  # pylint: disable=too-many-public-methods,too-many-instance-attrib
            - nomad.api.exceptions.URLNotFoundNomadException
            - nomad.api.exceptions.URLNotAuthorizedNomadException
         """
+        cert = cert or (os.getenv("NOMAD_CLIENT_CERT", None), os.getenv("NOMAD_CLIENT_KEY", None))
+
         self.host = host
         self.secure = secure
         self.port = port
-        self.address = address
+        self.address = address or os.getenv("NOMAD_ADDR", None)
         self.user_agent = user_agent
-        self.region = region
+        self.region = region or os.getenv("NOMAD_REGION", None)
         self.timeout = timeout
         self.version = version
-        self.token = token
+        self.token = token or os.getenv("NOMAD_TOKEN", None)
         self.verify = verify
         self.cert = cert if all(cert) else ()
         self.session = session
-        self.__namespace = namespace
+        self.__namespace = namespace or os.getenv("NOMAD_NAMESPACE", None)
 
         self.requester_settings = {
             "address": self.address,

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -9,7 +9,7 @@ if [ "${1-}" == "init" ]; then
     source .venv/bin/activate
 fi
 
-NOMAD_VERSION=`nomad --version | awk '{print $2}' | cut -c2-` 
+NOMAD_VERSION=`nomad --version | awk 'NR==1{print $2}' | cut -c2-` 
 
 echo "Run Nomad in dev mode"
 nomad agent -dev -node pynomad1 --acl-enabled &> nomad.log &

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -161,3 +161,10 @@ def test_use_custom_user_agent():
     n.jobs.get_jobs()
 
     assert responses.calls[0].request.headers["User-Agent"] == custom_agent_name
+
+def test_env_variables():
+    # This ensures that the env variables are only read upon initialization of Nomad() instance,
+    # and not before.
+    with mock.patch.dict(os.environ, {"NOMAD_ADDR": "https://foo"}):
+        n = nomad.Nomad()
+        assert n.address == os.environ["NOMAD_ADDR"]


### PR DESCRIPTION
The default values for arguments to `Nomad.__init__` are read when the class is initialized (so when python reads `__init__.py`.
If one later want to change the values of the `NOMAD_*` env variables, these new values will get ignored because by then the defaults for arguments are already set.

This changes the commit to have a proper `None` default, and only read the current values of env variables when `__init__()` is called.

See https://medium.com/@nebiyuelias1/be-careful-when-using-default-arguments-in-python-fd92df94efee for why defining the default with a function call is prone to error.