### PR TITLE
Fix nodes API filter

### DIFF
--- a/nomad/api/nodes.py
+++ b/nomad/api/nodes.py
@@ -87,7 +87,7 @@ class Nodes(Requester):
             "prefix": prefix,
             "next_token": next_token,
             "per_page": per_page,
-            "filter_": filter_,
+            "filter": filter_,
             "resources": resources,
             "os": os,
         }


### PR DESCRIPTION
The correct param is `filter` not `_filter`.