### PR TITLE
feat: Update dispatch jobs to support `templateprefix` and `idempotencytoken`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,12 +12,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
   
     - name: Set up Python 3
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.12'
+        python-version: '3.13'
 
     - name: Install Dependencies
       shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,8 +22,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7', '3.12'] # the oldest and newest support versions
-        nomad-version: ['1.2.16', '1.3.16', '1.4.14', '1.5.17', '1.6.10', '1.7.7']
+        python-version: ['3.8', '3.13'] # the oldest and newest support versions
+        nomad-version: ['1.4.14', '1.5.17', '1.6.10', '1.7.7', '1.8.4', '1.9.5']
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
@@ -41,7 +41,9 @@ jobs:
         curl -L -o /tmp/nomad_${NOMAD_VERSION}_linux_amd64.zip https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}_linux_amd64.zip
 
         echo "unzip nomad"
-        unzip -d /usr/local/bin/ /tmp/nomad_${NOMAD_VERSION}_linux_amd64.zip
+        unzip -o -d /usr/local/bin/ /tmp/nomad_${NOMAD_VERSION}_linux_amd64.zip
+        chmod +x /usr/local/bin/nomad
+        /usr/local/bin/nomad version
     - name: Install Dependencies
       shell: bash
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,4 +62,4 @@ jobs:
       run: |
         ./run_tests.sh
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v5

--- a/nomad/api/job.py
+++ b/nomad/api/job.py
@@ -246,12 +246,12 @@ class Job(Requester):
         return self.request(id_, "periodic", "force", method="post").json()
 
     def dispatch_job(
-      self,
-      id_,
-      payload=None,
-      meta=None,
-      id_prefix_template=None,
-      idempotency_token=None
+        self,
+        id_,
+        payload=None,
+        meta=None,
+        id_prefix_template=None,
+        idempotency_token=None,
     ):  # pylint: disable=too-many-arguments
         """Dispatches a new instance of a parameterized job.
 

--- a/nomad/api/job.py
+++ b/nomad/api/job.py
@@ -245,7 +245,14 @@ class Job(Requester):
         """
         return self.request(id_, "periodic", "force", method="post").json()
 
-    def dispatch_job(self, id_, payload=None, meta=None):
+    def dispatch_job(
+      self,
+      id_,
+      payload=None,
+      meta=None,
+      id_prefix_template=None,
+      idempotency_token=None
+    ):  # pylint: disable=too-many-arguments
         """Dispatches a new instance of a parameterized job.
 
         https://www.nomadproject.io/docs/http/job.html
@@ -254,12 +261,19 @@ class Job(Requester):
           - id_
           - payload
           - meta
+          - id_prefix_template
+          - idempotency_token
         returns: dict
         raises:
           - nomad.api.exceptions.BaseNomadException
           - nomad.api.exceptions.URLNotFoundNomadException
         """
-        dispatch_json = {"Meta": meta, "Payload": payload}
+        dispatch_json = {
+            "Meta": meta,
+            "Payload": payload,
+            "idempotency_token": idempotency_token,
+            "IdPrefixTemplate": id_prefix_template,
+        }
         return self.request(id_, "dispatch", json=dispatch_json, method="post").json()
 
     def revert_job(self, id_, version, enforce_prior_version=None):


### PR DESCRIPTION
fixes https://github.com/jrxFive/python-nomad/issues/158

- Also dropping older version of Nomad and adding newly introduced ones.
- bump action versions across different workflows
- dropping test skip conditions as no longer testing against those Nomad versions